### PR TITLE
add a file handler to be used with AD hdf5 plugin in Single mode

### DIFF
--- a/databroker/assets/handlers.py
+++ b/databroker/assets/handlers.py
@@ -281,9 +281,8 @@ class AreaDetector_HDF5SingleHandler_DataFrame(AreaDetector_HDF5SingleHandler):
                  column_names=None, frame_per_point=1):
         # I have included defaults for `key` and 'column_names' for back
         # compatibility with existing files at SIX.
-        super(AreaDetector_HDF5SingleHandler_DataFrame, self).__init__(
-              fpath=fpath, template=template, filename=filename, key=key,
-              frame_per_point=frame_per_point)
+        super().__init__(fpath=fpath, template=template, filename=filename,
+                         key=key, frame_per_point=frame_per_point)
         self._path = os.path.join(fpath, '')
         self._fpp = frame_per_point
         self._template = template

--- a/databroker/assets/handlers.py
+++ b/databroker/assets/handlers.py
@@ -217,7 +217,6 @@ class HDF5SingleHandler(HandlerBase):
     frame_per_point : float
         the number of frames per point.
     '''
-    specs = {'AD_HDF5_SINGLE'} | HandlerBase.specs
 
     def __init__(self, fpath, template, filename, key, frame_per_point=1):
         self._path = os.path.join(fpath, '')

--- a/databroker/assets/handlers.py
+++ b/databroker/assets/handlers.py
@@ -235,9 +235,9 @@ class AreaDetector_HDF5SingleHandler(HandlerBase):
 
     def _fnames_for_point(self, point_number):
         start = int(point_number * self._fpp)
-        stop = int((point_number + 1) * self._fpp)
+        stop = int(start + self._fpp)
         for j in range(start, stop):
-            yield self._template % (self._path, self._filename, j)
+            yield self._template.format(self._path, self._filename, j)
 
     def __call__(self, point_number):
         ret = []

--- a/databroker/assets/handlers.py
+++ b/databroker/assets/handlers.py
@@ -3,7 +3,6 @@ from __future__ import (absolute_import, division, print_function,
 import logging
 import numpy as np
 import os.path
-
 from .handlers_base import HandlerBase
 from .readers.spe import PrincetonSPEFile
 from pims import FramesSequence, Frame
@@ -201,6 +200,72 @@ class AreaDetectorHDF5Handler(HDF5DatasetSliceHandler):
         super(AreaDetectorHDF5Handler, self).__init__(
             filename=filename, key=hardcoded_key,
             frame_per_point=frame_per_point)
+
+
+class HDF5SingleHandler(HandlerBase):
+    '''Handler for hdf5 data stored 1 image per file.
+    Parameters
+    ----------
+    fpath : string
+        filepath
+    template : string
+        filename template string.
+    filename : string
+        filename
+    key : string
+        the 'path' inside the file to the data set.
+    frame_per_point : float
+        the number of frames per point.
+    '''
+    specs = {'AD_HDF5_SINGLE'} | HandlerBase.specs
+
+    def __init__(self, fpath, template, filename, key, frame_per_point=1):
+        self._path = os.path.join(fpath, '')
+        self._fpp = frame_per_point
+        self._template = template
+        self._filename = filename
+        self._key = key
+
+    def _fnames_for_point(self, point_number):
+        start = int(point_number * self._fpp)
+        stop = int((point_number + 1) * self._fpp)
+        for j in range(start, stop):
+            yield self._template % (self._path, self._filename, j)
+
+    def __call__(self, point_number):
+        import h5py
+        ret = []
+        for fn in self._fnames_for_point(point_number):
+            f = h5py.File(fn, 'r')
+            data = f[self._key]
+            ret.append(data)
+        return ret
+
+    def get_file_list(self, datum_kwargs):
+        ret = []
+        for d_kw in datum_kwargs:
+            ret.extend(self._fnames_for_point(**d_kw))
+        return ret
+
+
+class AreaDetectorHDF5SingleHandler(HDF5SingleHandler):
+    '''Handler for hdf5 data stored 1 image per file by areadetector
+    Parameters
+    ----------
+    fpath : string
+        filepath
+    template : string
+        filename template string.
+    filename : string
+        filename
+    frame_per_point : float
+        the number of frames per point.
+    '''
+    def __init__(self, fpath, template, filename, frame_per_point=1):
+        hardcoded_key = '/entry/data/data'
+        super(AreaDetectorHDF5SingleHandler, self).__init__(
+            fpath=fpath, template=template, filename=filename,
+            key=hardcoded_key, frame_per_point=frame_per_point)
 
 
 class AreaDetectorHDF5SWMRHandler(AreaDetectorHDF5Handler):


### PR DESCRIPTION
## Description:
This PR adds a new filestore handler that should be used with the new filestore mixin defined in the PR [here](https://github.com/NSLS-II/ophyd/pull/623)

## Motivation:
This was motivated by a custom plugin which has an array with one dimension determined only after running the plugin The result is that each `trigger` then creates a different sized array to the previous one, and so the `Streaming` mode which sets the array size prior to any `trigger`  did not correctly save the data.

## Testing:
This has been tested in the field as submitted here (NSLS-II, SIX beamline, rixscam detector, XIP plugin) and is working there.