### PR TITLE
allow for reversed databroker searches

### DIFF
--- a/databroker/headersource/core.py
+++ b/databroker/headersource/core.py
@@ -777,7 +777,9 @@ def bulk_insert_events(event_col, descriptor, events, validate):
 
 # DATABASE RETRIEVAL ##########################################################
 
-def find_run_starts(run_start_col, run_start_cache, tz, **kwargs):
+def find_run_starts(run_start_col, run_start_cache, tz,
+                    order='descending',
+                    **kwargs):
     """Given search criteria, locate RunStart Documents.
 
     Parameters
@@ -802,6 +804,8 @@ def find_run_starts(run_start_col, run_start_cache, tz, **kwargs):
         The username of the logged-in user when the scan was performed
     scan_id : int, optional
         Integer scan identifier
+    order : {'ascending', 'descending'}
+        The time order to return the headers in.
 
     Returns
     -------
@@ -822,8 +826,13 @@ def find_run_starts(run_start_col, run_start_cache, tz, **kwargs):
     # now try rest of formatting
     _format_time(kwargs, tz)
     _format_regex(kwargs)
-    rs_objects = run_start_col.find(kwargs,
-                                    sort=[('time', DESCENDING)])
+    if order == 'descending':
+        sort = [('time', DESCENDING)]
+    elif order == 'ascending':
+        sort = [('time', ASCENDING)]
+    else:
+        raise NotImplementedError('That order option is not implemented')
+    rs_objects = run_start_col.find(kwargs, sort=sort)
 
     for rs in rs_objects:
         yield _cache_run_start(rs, run_start_cache)

--- a/databroker/headersource/mongo_core.py
+++ b/databroker/headersource/mongo_core.py
@@ -128,7 +128,9 @@ def bulk_insert_events(event_col, descriptor, events, validate):
 # DATABASE RETRIEVAL ##########################################################
 
 
-def find_run_starts(run_start_col, run_start_cache, tz, **kwargs):
+def find_run_starts(run_start_col, run_start_cache, tz,
+                    order='descending',
+                    **kwargs):
     """Given search criteria, locate RunStart Documents.
 
     Parameters
@@ -153,6 +155,8 @@ def find_run_starts(run_start_col, run_start_cache, tz, **kwargs):
         The username of the logged-in user when the scan was performed
     scan_id : int, optional
         Integer scan identifier
+    order : {'ascending', 'descending'}
+        The time order to return the headers in.
 
     Returns
     -------
@@ -172,8 +176,13 @@ def find_run_starts(run_start_col, run_start_cache, tz, **kwargs):
     """
     # now try rest of formatting
     _format_time(kwargs, tz)
-    rs_objects = run_start_col.find(kwargs,
-                                    sort=[('time', pymongo.DESCENDING)])
+    if order == 'descending':
+        sort = [('time', pymongo.DESCENDING)]
+    elif order == 'ascending':
+        sort = [('time', pymongo.ASCENDING)]
+    else:
+        raise NotImplementedError('That order option is not implemented')
+    rs_objects = run_start_col.find(kwargs, sort=sort)
 
     for rs in rs_objects:
         yield _cache_run_start(rs, run_start_cache)

--- a/databroker/tests/test_broker.py
+++ b/databroker/tests/test_broker.py
@@ -1262,3 +1262,16 @@ def test_monitoring(db, RE, hw):
     sd.monitors.append(hw.rand)
     RE(bp.count([hw.det], 5, delay=1))
     assert len(db[-1].table('rand_monitor')) > 1
+
+
+def test_search_order(db, RE, hw):
+    RE.subscribe(db.insert)
+    RE(count([hw.det], 5))
+    RE(count([hw.det], 5))
+
+    hdrs1 = db(order='descending')
+    hdrs2 = db(order='ascending')
+
+    for h1, h2 in zip(list(hdrs1), reversed(list(hdrs2))):
+        assert h1 == h2
+


### PR DESCRIPTION
This will be helpful when trying to rerun an entire series of experiments
in order.