### PR TITLE
CLN: remove dask dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,5 @@
 attrs>=17.4.0
 boltons
-dask
 doct
 humanize
 jinja2


### PR DESCRIPTION
To address https://github.com/NSLS-II/PyXRF/issues/159#issuecomment-504426739.

This change may be temporary, as dask may be introduced in the later major versions.