### PR TITLE
REF: replace deprecated unordered bulk op

### DIFF
--- a/databroker/assets/mongo_core.py
+++ b/databroker/assets/mongo_core.py
@@ -68,12 +68,12 @@ def bulk_insert_datum(col, resource, datum_ids,
                          datum_kwargs=dict(d_kwargs))
             yield datum
 
-    bulk = col.initialize_unordered_bulk_op()
     d_uids = deque()
+    bulk = deque()
     for dm in datum_factory():
-        bulk.insert(dm)
+        bulk.append(pymongo.InsertOne(dm))
         d_uids.append(dm['datum_id'])
-    bulk.execute()
+    col.bulk_write(bulk, ordered=False)
     return d_uids
 
 

--- a/databroker/assets/mongo_core.py
+++ b/databroker/assets/mongo_core.py
@@ -69,7 +69,7 @@ def bulk_insert_datum(col, resource, datum_ids,
             yield datum
 
     d_uids = deque()
-    bulk = deque()
+    bulk = []
     for dm in datum_factory():
         bulk.append(pymongo.InsertOne(dm))
         d_uids.append(dm['datum_id'])

--- a/databroker/headersource/mongo_core.py
+++ b/databroker/headersource/mongo_core.py
@@ -119,7 +119,8 @@ def bulk_insert_events(event_col, descriptor, events, validate):
                           seq_num=ev['seq_num'])
             yield ev_out
 
-    return event_col.bulk_write(list(event_factory()), ordered=True)
+    bulk = [pymongo.InsertOne(ev) for ev in event_factory()]
+    return event_col.bulk_write(bulk, ordered=True)
 
 # DATABASE RETRIEVAL ##########################################################
 

--- a/databroker/headersource/mongo_core.py
+++ b/databroker/headersource/mongo_core.py
@@ -119,11 +119,7 @@ def bulk_insert_events(event_col, descriptor, events, validate):
                           seq_num=ev['seq_num'])
             yield ev_out
 
-    bulk = event_col.initialize_ordered_bulk_op()
-    for ev in event_factory():
-        bulk.insert(ev)
-
-    return bulk.execute()
+    return event_col.bulk_write(list(event_factory()), ordered=True)
 
 # DATABASE RETRIEVAL ##########################################################
 

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -7,3 +7,4 @@ pathlib
 pyqt5
 pytest
 vcrpy
+ujson

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ with open(path.join(here, 'requirements.txt')) as f:
     requirements = f.read().split()
 
 extras_require = {
-    'mongo': ['pymongo'],
+    'mongo': ['pymongo>=3.0'],
     'hdf5': ['h5py'],
     'client': ['requests'],
     'service': ['tornado<6', 'ujson'],


### PR DESCRIPTION
* `ujson` appears to be a dependency of a dependency, which was not picked up when I installed the requirements in a pre-existing environment
* Deprecation information: https://api.mongodb.com/python/current/api/pymongo/collection.html?highlight=unordered%20bulk#pymongo.collection.Collection.initialize_unordered_bulk_op
* Replaced with: https://api.mongodb.com/python/current/api/pymongo/collection.html?highlight=unordered%20bulk#pymongo.collection.Collection.bulk_write
* bulk_write requires pymongo >= 3.0