### PR TITLE
BLD: add missing files to PyPI sdist

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,3 +1,10 @@
-include versioneer.py
 include databroker/_version.py
 include databroker/assets/schemas/*.json
+recursive-include doc/source *
+include doc/Makefile doc/make.bat
+include LICENSE
+include MANIFEST.in
+include README.md
+include requirements.txt
+include setup.py
+include versioneer.py


### PR DESCRIPTION
The required files are missing from the source distribution on PyPI. See https://dev.azure.com/nsls2forge/nsls2forge/_build/results?buildId=442 for the details.