### PR TITLE
Add root_map

### DIFF
--- a/databroker/_drivers/jsonl.py
+++ b/databroker/_drivers/jsonl.py
@@ -55,7 +55,7 @@ class BlueskyJSONLCatalog(BlueskyInMemoryCatalog):
     name = 'bluesky-jsonl-catalog'  # noqa
 
     def __init__(self, paths, *,
-                 handler_registry=None, query=None, **kwargs):
+                 handler_registry=None, root_map=None, query=None, **kwargs):
         """
         This Catalog is backed by a newline-delimited JSON (jsonl) file.
 
@@ -71,6 +71,8 @@ class BlueskyJSONLCatalog(BlueskyInMemoryCatalog):
             Maps each asset spec to a handler class or a string specifying the
             module name and class name, as in (for example)
             ``{'SOME_SPEC': 'module.submodule.class_name'}``.
+        root_map : dict, optional
+            Maps resource root paths to different paths.
         query : dict, optional
             Mongo query that filters entries' RunStart documents
         **kwargs :
@@ -83,6 +85,7 @@ class BlueskyJSONLCatalog(BlueskyInMemoryCatalog):
         self.paths = paths
         self._filename_to_mtime = {}
         super().__init__(handler_registry=handler_registry,
+                         root_map=root_map,
                          query=query,
                          **kwargs)
 
@@ -119,6 +122,7 @@ class BlueskyJSONLCatalog(BlueskyInMemoryCatalog):
             paths=self.paths,
             query=query,
             handler_registry=self.filler.handler_registry,
+            root_map=self.filler.root_map,
             name='search results',
             getenv=self.getenv,
             getshell=self.getshell,

--- a/databroker/_drivers/mongo_embedded.py
+++ b/databroker/_drivers/mongo_embedded.py
@@ -207,7 +207,7 @@ class BlueskyMongoCatalog(Broker):
             handler_registry = {}
         parsed_handler_registry = parse_handler_registry(handler_registry)
         self.filler = event_model.Filler(
-            parsed_handler_registry, root_map=None, inplace=True)
+            parsed_handler_registry, root_map=root_map, inplace=True)
         super().__init__(**kwargs)
 
     def _get_event_pages(self, descriptor_uid, skip=0, limit=None):

--- a/databroker/_drivers/mongo_embedded.py
+++ b/databroker/_drivers/mongo_embedded.py
@@ -168,7 +168,7 @@ class _Entries(collections.abc.Mapping):
 
 
 class BlueskyMongoCatalog(Broker):
-    def __init__(self, datastore_db, *, handler_registry=None,
+    def __init__(self, datastore_db, *, handler_registry=None, root_map=None,
                  query=None, **kwargs):
         """
         This Catalog is backed by a MongoDB with an embedded data model.
@@ -186,6 +186,8 @@ class BlueskyMongoCatalog(Broker):
             Maps each asset spec to a handler class or a string specifying the
             module name and class name, as in (for example)
             ``{'SOME_SPEC': 'module.submodule.class_name'}``.
+        root_map : dict, optional
+            Maps resource root paths to different paths.
         query : dict, optional
             MongoDB query. Used internally by the ``search()`` method.
         **kwargs :
@@ -204,7 +206,8 @@ class BlueskyMongoCatalog(Broker):
         if handler_registry is None:
             handler_registry = {}
         parsed_handler_registry = parse_handler_registry(handler_registry)
-        self.filler = event_model.Filler(parsed_handler_registry, inplace=True)
+        self.filler = event_model.Filler(
+            parsed_handler_registry, root_map=None, inplace=True)
         super().__init__(**kwargs)
 
     def _get_event_pages(self, descriptor_uid, skip=0, limit=None):
@@ -261,6 +264,7 @@ class BlueskyMongoCatalog(Broker):
             datastore_db=self._db,
             query=query,
             handler_registry=self.filler.handler_registry,
+            root_map=self.filler.root_map,
             name='search results',
             getenv=self.getenv,
             getshell=self.getshell,

--- a/databroker/_drivers/mongo_normalized.py
+++ b/databroker/_drivers/mongo_normalized.py
@@ -129,7 +129,7 @@ class _Entries(collections.abc.Mapping):
 
 class BlueskyMongoCatalog(Broker):
     def __init__(self, metadatastore_db, asset_registry_db, *,
-                 handler_registry=None, query=None, **kwargs):
+                 handler_registry=None, root_map=None, query=None, **kwargs):
         """
         This Catalog is backed by a pair of MongoDBs with "layout 1".
 
@@ -146,6 +146,8 @@ class BlueskyMongoCatalog(Broker):
             Maps each asset spec to a handler class or a string specifying the
             module name and class name, as in (for example)
             ``{'SOME_SPEC': 'module.submodule.class_name'}``.
+        root_map : dict, optional
+            Maps resource root paths to different paths.
         query : dict, optional
             MongoDB query. Used internally by the ``search()`` method.
         **kwargs :
@@ -178,7 +180,8 @@ class BlueskyMongoCatalog(Broker):
         if handler_registry is None:
             handler_registry = {}
         parsed_handler_registry = parse_handler_registry(handler_registry)
-        self.filler = event_model.Filler(parsed_handler_registry, inplace=True)
+        self.filler = event_model.Filler(
+                parsed_handler_registry, root_map=root_map, inplace=True)
         super().__init__(**kwargs)
 
     def _get_run_stop(self, run_start_uid):
@@ -267,6 +270,7 @@ class BlueskyMongoCatalog(Broker):
             asset_registry_db=self._asset_registry_db,
             query=query,
             handler_registry=self.filler.handler_registry,
+            root_map=self.filler.root_map,
             name='search results',
             getenv=self.getenv,
             getshell=self.getshell,

--- a/databroker/_drivers/msgpack.py
+++ b/databroker/_drivers/msgpack.py
@@ -50,7 +50,7 @@ class BlueskyMsgpackCatalog(BlueskyInMemoryCatalog):
     name = 'bluesky-msgpack-catalog'  # noqa
 
     def __init__(self, paths, *,
-                 handler_registry=None, query=None, **kwargs):
+                 handler_registry=None, root_map=None, query=None, **kwargs):
         """
         This Catalog is backed by msgpack files.
 
@@ -66,6 +66,8 @@ class BlueskyMsgpackCatalog(BlueskyInMemoryCatalog):
             Maps each asset spec to a handler class or a string specifying the
             module name and class name, as in (for example)
             ``{'SOME_SPEC': 'module.submodule.class_name'}``.
+        root_map : dict, optional
+            Maps resource root paths to different paths.
         query : dict, optional
             Mongo query that filters entries' RunStart documents
         **kwargs :
@@ -78,6 +80,7 @@ class BlueskyMsgpackCatalog(BlueskyInMemoryCatalog):
         self.paths = paths
         self._filename_to_mtime = {}
         super().__init__(handler_registry=handler_registry,
+                         root_map=root_map,
                          query=query,
                          **kwargs)
 
@@ -113,6 +116,7 @@ class BlueskyMsgpackCatalog(BlueskyInMemoryCatalog):
             paths=self.paths,
             query=query,
             handler_registry=self.filler.handler_registry,
+            root_map=self.filler.root_map,
             name='search results',
             getenv=self.getenv,
             getshell=self.getshell,

--- a/databroker/in_memory.py
+++ b/databroker/in_memory.py
@@ -22,7 +22,8 @@ class SafeLocalCatalogEntry(intake.catalog.local.LocalCatalogEntry):
 class BlueskyInMemoryCatalog(Broker):
     name = 'bluesky-run-catalog'  # noqa
 
-    def __init__(self, handler_registry=None, query=None, **kwargs):
+    def __init__(self, handler_registry=None, root_map=None, query=None,
+                 **kwargs):
         """
         This Catalog is backed by Python collections in memory.
 
@@ -36,6 +37,8 @@ class BlueskyInMemoryCatalog(Broker):
             Maps each asset spec to a handler class or a string specifying the
             module name and class name, as in (for example)
             ``{'SOME_SPEC': 'module.submodule.class_name'}``.
+        root_map : dict, optional
+            Maps resource root paths to different paths.
         query : dict, optional
             Mongo query that filters entries' RunStart documents
         **kwargs :
@@ -46,7 +49,8 @@ class BlueskyInMemoryCatalog(Broker):
         if handler_registry is None:
             handler_registry = {}
         parsed_handler_registry = parse_handler_registry(handler_registry)
-        self.filler = event_model.Filler(parsed_handler_registry, inplace=True)
+        self.filler = event_model.Filler(
+            parsed_handler_registry, root_map=root_map, inplace=True)
         self._uid_to_run_start_doc = {}
         super().__init__(**kwargs)
 
@@ -88,6 +92,7 @@ class BlueskyInMemoryCatalog(Broker):
         cat = type(self)(
             query=query,
             handler_registry=self.filler.handler_registry,
+            root_map=self.filler.root_map,
             name='search results',
             getenv=self.getenv,
             getshell=self.getshell,


### PR DESCRIPTION
Currently ``root_map`` can only be set after `__init__`, via

```
cat = SomeCatalogClass(...)
cat.filler.root_map = {...}
```

and, moreover, it does not propagate into serach results. It obviously
should propagate into search results.

And it should be settable via `__init__` for consitency with
``handler_registry`` and so that it can be set in configuration files.