### PR TITLE
Discover handlers via 'databroker.handlers' entrypoint.

### DIFF
--- a/databroker/_drivers/mongo_embedded.py
+++ b/databroker/_drivers/mongo_embedded.py
@@ -9,7 +9,7 @@ import intake.source.base
 import pymongo
 import pymongo.errors
 
-from ..core import parse_handler_registry
+from ..core import parse_handler_registry, discover_handlers
 from ..v2 import Broker
 
 
@@ -185,7 +185,8 @@ class BlueskyMongoCatalog(Broker):
         handler_registry : dict, optional
             Maps each asset spec to a handler class or a string specifying the
             module name and class name, as in (for example)
-            ``{'SOME_SPEC': 'module.submodule.class_name'}``.
+            ``{'SOME_SPEC': 'module.submodule.class_name'}``. If None, the
+            result of ``databroker.core.discover_handlers()`` is used.
         root_map : dict, optional
             Maps resource root paths to different paths.
         query : dict, optional
@@ -204,7 +205,7 @@ class BlueskyMongoCatalog(Broker):
         self._query = query or {}
 
         if handler_registry is None:
-            handler_registry = {}
+            handler_registry = discover_handlers()
         parsed_handler_registry = parse_handler_registry(handler_registry)
         self.filler = event_model.Filler(
             parsed_handler_registry, root_map=root_map, inplace=True)

--- a/databroker/_drivers/mongo_normalized.py
+++ b/databroker/_drivers/mongo_normalized.py
@@ -8,7 +8,7 @@ import intake.source.base
 import pymongo
 import pymongo.errors
 
-from ..core import parse_handler_registry
+from ..core import parse_handler_registry, discover_handlers
 from ..core import to_event_pages
 from ..core import to_datum_pages
 from ..v2 import Broker
@@ -145,7 +145,8 @@ class BlueskyMongoCatalog(Broker):
         handler_registry : dict, optional
             Maps each asset spec to a handler class or a string specifying the
             module name and class name, as in (for example)
-            ``{'SOME_SPEC': 'module.submodule.class_name'}``.
+            ``{'SOME_SPEC': 'module.submodule.class_name'}``. If None, the
+            result of ``databroker.core.discover_handlers()`` is used.
         root_map : dict, optional
             Maps resource root paths to different paths.
         query : dict, optional
@@ -178,7 +179,7 @@ class BlueskyMongoCatalog(Broker):
 
         self._query = query or {}
         if handler_registry is None:
-            handler_registry = {}
+            handler_registry = discover_handlers()
         parsed_handler_registry = parse_handler_registry(handler_registry)
         self.filler = event_model.Filler(
                 parsed_handler_registry, root_map=root_map, inplace=True)

--- a/databroker/core.py
+++ b/databroker/core.py
@@ -1,5 +1,6 @@
 import collections
 import copy
+import entrypoints
 import event_model
 from datetime import datetime
 import dask
@@ -1063,6 +1064,53 @@ def xarray_to_event_gen(data_xarr, ts_xarr, page_size):
         event_page['filled'] = {}
 
         yield event_page
+
+
+def discover_handlers(entrypoint_group_name='databroker.handlers',
+                      skip_failures=True):
+    """
+    Discover handlers via entrypoints.
+
+    Parameters
+    ----------
+    entrypoint_group_name: str
+        Default is 'databroker.handlers', the "official" databroker entrypoint
+        for handlers.
+    skip_failures: boolean
+        True by default. Errors loading a handler class are converted to
+        warnings if this is True.
+
+    Returns
+    -------
+    handler_registry: dict
+        A suitable default handler registry
+    """
+    group = entrypoints.get_group_named(entrypoint_group_name)
+    group_all = entrypoints.get_group_all(entrypoint_group_name)
+    if len(group_all) != len(group):
+        # There are some name collisions. Let's go digging for them.
+        for name, matches in itertools.groupby(group_all, lambda ep: ep.name):
+            matches = list(matches)
+            if len(matches) != 1:
+                winner = group[name]
+                warnings.warn(
+                    f"There are {len(matches)} entrypoints for the "
+                    f"databroker handler spec {name!r}."
+                    f"They are {matches}. The match {winner} has won the race.")
+    handler_registry = {}
+    for name, entrypoint in group.items():
+        try:
+            handler_class = entrypoint.load()
+        except Exception as exc:
+            if skip_failures:
+                warnings.warn("Skipping {entrypoint!r} which failed to load. "
+                              "Exception: {exc!r}")
+                continue
+            else:
+                raise
+        handler_registry[name] = entrypoint.load()
+
+    return handler_registry
 
 
 def parse_handler_registry(handler_registry):

--- a/databroker/core.py
+++ b/databroker/core.py
@@ -1095,7 +1095,7 @@ def discover_handlers(entrypoint_group_name='databroker.handlers',
                 winner = group[name]
                 warnings.warn(
                     f"There are {len(matches)} entrypoints for the "
-                    f"databroker handler spec {name!r}."
+                    f"databroker handler spec {name!r}. "
                     f"They are {matches}. The match {winner} has won the race.")
     handler_registry = {}
     for name, entrypoint in group.items():

--- a/databroker/in_memory.py
+++ b/databroker/in_memory.py
@@ -7,7 +7,7 @@ import intake.source.base
 from mongoquery import Query
 
 
-from .core import parse_handler_registry
+from .core import parse_handler_registry, discover_handlers
 from .v2 import Broker
 
 
@@ -36,7 +36,8 @@ class BlueskyInMemoryCatalog(Broker):
         handler_registry : dict, optional
             Maps each asset spec to a handler class or a string specifying the
             module name and class name, as in (for example)
-            ``{'SOME_SPEC': 'module.submodule.class_name'}``.
+            ``{'SOME_SPEC': 'module.submodule.class_name'}``. If None, the
+            result of ``databroker.core.discover_handlers()`` is used.
         root_map : dict, optional
             Maps resource root paths to different paths.
         query : dict, optional
@@ -47,7 +48,7 @@ class BlueskyInMemoryCatalog(Broker):
         """
         self._query = query or {}
         if handler_registry is None:
-            handler_registry = {}
+            handler_registry = discover_handlers()
         parsed_handler_registry = parse_handler_registry(handler_registry)
         self.filler = event_model.Filler(
             parsed_handler_registry, root_map=root_map, inplace=True)


### PR DESCRIPTION
Continuing our theme of using entrypoints for discovery, this adds a new
``'databroker.handlers'`` entrypoint which packages can use to declare that
they ship some classes that may be used as handlers for certain specs.

This means that a handler registry can be specified:

1. directly, by passing a dict into the Catalog's `__init__`
2. via a v0-style configuration file that specifies a dict _to be passed_ into `__init__`
3. via an intake-style `catalog.yml` file with the same effect as (2)
4. implicitly, by discovering all installed handlers via the `'databroker.handlers'` entrypoint

Notice that we avoid any potentially-confusing configuration "merging" here.
Approach (4) is only activated if none of the other approaches are used and
thus ``handler_registry=None`` is passed in to the Catalog's ``__init__``.
But Approach (4) is convenient and likely sufficient for many users. If they

```
pip install area-detector-handlers  # new package, just added to PyPI
```

then databroker can discover the handlers that it declares

```py
In [1]: import databroker.core                                                                                                                                                                

In [2]: databroker.core.discover_handlers()                                                                                                                                                   
Out[2]: 
{'AD_CBF': area_detector_handlers.handlers.PilatusCBFHandler,
 'AD_HDF5': area_detector_handlers.handlers.AreaDetectorHDF5Handler,
 'AD_HDF5_SWMR': area_detector_handlers.handlers.AreaDetectorHDF5SWMRHandler,
 'AD_HDF5_SWMR_TS': area_detector_handlers.handlers.AreaDetectorHDF5SWMRTimestampHandler,
 'AD_HDF5_TS': area_detector_handlers.handlers.AreaDetectorHDF5TimestampHandler,
 'AD_SPE': area_detector_handlers.handlers.AreaDetectorSPEHandler,
 'AD_TIFF': area_detector_handlers.handlers.AreaDetectorTiffHandler,
 'XSP3': area_detector_handlers.handlers.Xspress3HDF5Handler}
```

and it will use this as its ``handler_registry`` unless a different one is
specified.

This was intentionally done at the databroker level, not in
``event_model.Filler`` so that the `Filler` always gets an explicit
``handler_registry`` and does not get involved in configuration management.