### PR TITLE
Give dimensions unique names.

### DIFF
--- a/databroker/core.py
+++ b/databroker/core.py
@@ -276,6 +276,7 @@ def documents_to_xarray(*, start_doc, stop_doc, descriptor_docs,
             keys = list(data_keys)
 
     # Collect a Dataset for each descriptor. Merge at the end.
+    dim_counter = itertools.count()
     datasets = []
     for descriptor in descriptor_docs:
         events = list(flatten_event_page_gen(get_event_pages(descriptor['uid'])))
@@ -324,7 +325,7 @@ def documents_to_xarray(*, start_doc, stop_doc, descriptor_docs,
                     ...
             if dims is None:
                 # Construct the same default dimension names xarray would.
-                dims = tuple(f'dim_{i}' for i in range(ndim))
+                dims = tuple(f'dim_{next(dim_counter)}' for _ in range(ndim))
             data_arrays[key] = xarray.DataArray(
                 data=data_table[key],
                 dims=('time',) + dims,
@@ -362,7 +363,7 @@ def documents_to_xarray(*, start_doc, stop_doc, descriptor_docs,
                         ...
                 if dims is None:
                     # Construct the same default dimension names xarray would.
-                    dims = tuple(f'dim_{i}' for i in range(ndim))
+                    dims = tuple(f'dim_{next(dim_counter)}' for _ in range(ndim))
                 data_arrays[scoped_key] = xarray.DataArray(
                     # TODO Once we know we have one Event Descriptor
                     # per stream we can be more efficient about this.


### PR DESCRIPTION
Before this change assembling the DataArrays into one Dataset
raised an error because multiple DataArrays used the same dimension name
(such as ``dim_0``) to mean different things. Xarray detected that
one DataArrays's ``dim_0`` had a different shape than another
DataArray's ``dim_0`` and thus (correctly!) refused to combine them into
one Dataset, raising an error like:

```
ValueError: arguments without labels along dimension 'dim_0' cannot be aligned because they have different dimension sizes: {1, 2, 3, 4, 5, 38, 7, 14, 18}
```

This PR ensures unique dimension names across the whole Dataset. This
fallback will become less important once we start providing names for
the dimensions through ``device.describe()``, making use of the 'dims'
key that was added to the event model.