### PR TITLE
This ensures that the query is a dict.

### DIFF
--- a/databroker/_drivers/jsonl.py
+++ b/databroker/_drivers/jsonl.py
@@ -116,6 +116,7 @@ class BlueskyJSONLCatalog(BlueskyInMemoryCatalog):
         ----------
         query : dict
         """
+        query = dict(query)
         if self._query:
             query = {'$and': [self._query, query]}
         cat = type(self)(

--- a/databroker/_drivers/mongo_embedded.py
+++ b/databroker/_drivers/mongo_embedded.py
@@ -257,6 +257,7 @@ class BlueskyMongoCatalog(Broker):
         query : dict
             MongoDB query.
         """
+        query = dict(query)
         if query:
             query = {f"start.{key}": val for key, val in query.items()}
         if self._query:

--- a/databroker/_drivers/mongo_normalized.py
+++ b/databroker/_drivers/mongo_normalized.py
@@ -264,6 +264,7 @@ class BlueskyMongoCatalog(Broker):
         query : dict
             MongoDB query.
         """
+        query = dict(query)
         if self._query:
             query = {'$and': [self._query, query]}
         cat = type(self)(

--- a/databroker/_drivers/msgpack.py
+++ b/databroker/_drivers/msgpack.py
@@ -110,6 +110,7 @@ class BlueskyMsgpackCatalog(BlueskyInMemoryCatalog):
         ----------
         query : dict
         """
+        query = dict(query)
         if self._query:
             query = {'$and': [self._query, query]}
         cat = type(self)(


### PR DESCRIPTION
We accept anything that is dict-like, as in a
``databroker.queries.Query``, but for msgpack-serialization in the
client--server use case, we need to make this a literal dict.