### PR TITLE
Use vendored intake-xarray.

### DIFF
--- a/databroker/core.py
+++ b/databroker/core.py
@@ -13,7 +13,6 @@ import itertools
 import intake.catalog.base
 import errno
 import intake.container.base
-import intake_xarray.base
 from intake.compat import unpack_kwargs
 import msgpack
 import requests
@@ -23,6 +22,7 @@ import os
 import warnings
 import xarray
 
+from .intake_xarray_core.base import DataSourceMixin
 
 def tail(filename, n=1, bsize=2048):
     """
@@ -812,7 +812,7 @@ class BlueskyRun(intake.catalog.Catalog):
             "also help, if available.")
 
 
-class BlueskyEventStream(intake_xarray.base.DataSourceMixin):
+class BlueskyEventStream(DataSourceMixin):
     """
     Catalog representing one Event Stream from one Run.
 
@@ -850,7 +850,7 @@ class BlueskyEventStream(intake_xarray.base.DataSourceMixin):
     **kwargs :
         Additional keyword arguments are passed through to the base class.
     """
-    container = 'xarray'
+    container = 'databroker-xarray'
     name = 'bluesky-event-stream'
     version = '0.0.1'
     partition_access = True

--- a/databroker/intake_xarray_core/__init__.py
+++ b/databroker/intake_xarray_core/__init__.py
@@ -1,14 +1,5 @@
-from ._version import get_versions
-__version__ = get_versions()['version']
-del get_versions
-
 import intake  # Import this first to avoid circular imports during discovery.
-from .netcdf import NetCDFSource
-from .opendap import OpenDapSource
-from .raster import RasterIOSource
-from .xzarr import ZarrSource
 from .xarray_container import RemoteXarray
-from .image import ImageSource
 
 import intake.container
 

--- a/databroker/intake_xarray_core/__init__.py
+++ b/databroker/intake_xarray_core/__init__.py
@@ -3,5 +3,5 @@ from .xarray_container import RemoteXarray
 
 import intake.container
 
-intake.registry['remote-xarray'] = RemoteXarray
-intake.container.container_map['xarray'] = RemoteXarray
+intake.registry['databroker-remote-xarray'] = RemoteXarray
+intake.container.container_map['databroker-xarray'] = RemoteXarray

--- a/databroker/intake_xarray_core/base.py
+++ b/databroker/intake_xarray_core/base.py
@@ -2,13 +2,11 @@ import json
 
 import dask.array
 
-from .. import __version__
 from intake.source.base import DataSource, Schema
 
 
 class DataSourceMixin(DataSource):
     """Common behaviours for plugins in this repo"""
-    version = __version__
     container = 'databroker-xarray'
     partition_access = True
 

--- a/databroker/intake_xarray_core/base.py
+++ b/databroker/intake_xarray_core/base.py
@@ -2,14 +2,14 @@ import json
 
 import dask.array
 
-from . import __version__
+from .. import __version__
 from intake.source.base import DataSource, Schema
 
 
 class DataSourceMixin(DataSource):
     """Common behaviours for plugins in this repo"""
     version = __version__
-    container = 'xarray'
+    container = 'databroker-xarray'
     partition_access = True
 
     def _get_schema(self):

--- a/databroker/intake_xarray_core/xarray_container.py
+++ b/databroker/intake_xarray_core/xarray_container.py
@@ -68,8 +68,8 @@ class RemoteXarray(RemoteSource):
     """
     An xarray data source on the server
     """
-    name = 'remote-xarray'
-    container = 'xarray'
+    name = 'databroker-remote-xarray'
+    container = 'databroker-xarray'
 
     def __init__(self, url, headers, **kwargs):
         """

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,6 @@ doct
 event-model >=1.11.1b1
 humanize
 intake >=0.5.2  # first release to use entrypoints
-intake-xarray >=0.3.1  # first release to use entrypoints
 jinja2
 jsonschema
 mongoquery

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 boltons
-dask[bag]
+dask[array,bag]
 doct
 event-model >=1.11.1b1
 humanize
@@ -23,3 +23,4 @@ tifffile
 toolz
 tzlocal
 xarray
+zarr

--- a/setup.py
+++ b/setup.py
@@ -78,6 +78,7 @@ setup(
              'databroker._drivers.mongo_normalized:BlueskyMongoCatalog'),
             'bluesky-msgpack-catalog = databroker._drivers.msgpack:BlueskyMsgpackCatalog',
             'bluesky-run = databroker.core:BlueskyRun',
+            'databroker-remote-xarray = databroker.intake_xarray_core.xarray_container:RemoteXarray',
         ]
     },
 


### PR DESCRIPTION
The motivation is to avoid taking on all the format-specific dependencies
in intake-xarray and just use the server--client piece.