### PR TITLE
API: canonical(...) always returns EventPage, never Event.

### DIFF
--- a/databroker/core.py
+++ b/databroker/core.py
@@ -760,7 +760,8 @@ class BlueskyRun(intake.catalog.Catalog):
                             datum_ids |= set(datum_page['datum_id'])
                 if fill == 'yes':
                     self._fill(event)  # in place (for now)
-                payload.append(('event', event))
+                event_page = event_model.pack_event_page(event)
+                payload.append(('event_page', event_page))
             if i == self.npartitions - 1 and self._run_stop_doc is not None:
                 payload.append(('stop', self._run_stop_doc))
         for _, doc in payload:

--- a/databroker/v1.py
+++ b/databroker/v1.py
@@ -1688,7 +1688,7 @@ class _GetDocumentsRouter:
     def event_page(self, doc):
         "Unpack into events and pass them to event method for more processing."
         if doc['descriptor'] in self._descriptors:
-            for event in event_model.unpack_event_page(event):
+            for event in event_model.unpack_event_page(doc):
                 yield from self.event(event)
 
     def event(self, doc):

--- a/databroker/v1.py
+++ b/databroker/v1.py
@@ -422,9 +422,9 @@ class Broker:
             def merge_config_into_event(event):
                 # Mutate event in place, adding in data and timestamps from the
                 # descriptor's 'configuration' key.
-                event_data = doc['data']  # cache for perf
-                desc = doc['descriptor']
-                event_timestamps = doc['timestamps']
+                event_data = event['data']  # cache for perf
+                desc = event['descriptor']
+                event_timestamps = event['timestamps']
                 event_data.update(per_desc_extra_data[desc])
                 event_timestamps.update(per_desc_extra_ts[desc])
                 discard_fields = per_desc_discards[desc]

--- a/databroker/v1.py
+++ b/databroker/v1.py
@@ -923,7 +923,10 @@ class Broker:
 
         for header in headers:
             for name, doc in self._catalog[header.start['uid']].canonical(fill='no'):
-                if name == 'resource' and new_root:
+                if name == 'event_page':
+                    for event in event_model.unpack_event_page(doc):
+                        db.insert('event', event)
+                elif name == 'resource' and new_root:
                     file_pairs.extend(self.reg.copy_files(doc, new_root, **copy_kwargs))
                     new_resource = copy.deepcopy(doc)
                     new_resource['root'] = new_root


### PR DESCRIPTION
Thus, all *new* consumer code, using the `canonical(...)` method, will be
written to expected EventPages and thus do things in an efficient, vectorized
way.

Note that DatumPages were already handled correctly, so no changes were needed
for Datum.

This change exposed some typos in codepaths that were not previously covered.