### PR TITLE
Get entry on getitem

### DIFF
--- a/databroker/_drivers/mongo_embedded.py
+++ b/databroker/_drivers/mongo_embedded.py
@@ -152,7 +152,13 @@ class _Entries(collections.abc.Mapping):
                     raise KeyError(f"No run with scan_id={N}")
         if header_doc is None:
             raise KeyError(name)
-        return self._doc_to_entry(header_doc['start'][0])
+        entry = self._doc_to_entry(header_doc['start'][0])
+        # The user has requested one specific Entry. In order to give them a
+        # more useful object, 'get' the Entry for them. Note that if they are
+        # expecting an Entry and try to call ``()`` or ``.get()``, that will
+        # still work because BlueskyRun supports those methods and will just
+        # return itself.
+        return entry.get()  # an instance of BlueskyRun
 
     def __contains__(self, key):
         # Avoid iterating through all entries.

--- a/databroker/_drivers/mongo_embedded.py
+++ b/databroker/_drivers/mongo_embedded.py
@@ -9,7 +9,7 @@ import intake.source.base
 import pymongo
 import pymongo.errors
 
-from ..core import parse_handler_registry, discover_handlers
+from ..core import parse_handler_registry, discover_handlers, Entry
 from ..v2 import Broker
 
 
@@ -79,7 +79,7 @@ class _Entries(collections.abc.Mapping):
             lookup_resource_for_datum=lookup_resource_for_datum,
             get_datum_pages=self.catalog._get_datum_pages,
             filler=self.catalog.filler)
-        return intake.catalog.local.LocalCatalogEntry(
+        return Entry(
             name=run_start_doc['uid'],
             description={},  # TODO
             driver='databroker.core.BlueskyRun',

--- a/databroker/_drivers/mongo_normalized.py
+++ b/databroker/_drivers/mongo_normalized.py
@@ -8,9 +8,9 @@ import intake.source.base
 import pymongo
 import pymongo.errors
 
-from ..core import parse_handler_registry, discover_handlers
-from ..core import to_event_pages
-from ..core import to_datum_pages
+from ..core import (
+    parse_handler_registry, discover_handlers, to_event_pages, to_datum_pages,
+    Entry)
 from ..v2 import Broker
 
 
@@ -42,7 +42,7 @@ class _Entries(collections.abc.Mapping):
             # benchmarks.
             get_datum_pages=to_datum_pages(self.catalog._get_datum_cursor, 2500),
             filler=self.catalog.filler)
-        return intake.catalog.local.LocalCatalogEntry(
+        return Entry(
             name=run_start_doc['uid'],
             description={},  # TODO
             driver='databroker.core.BlueskyRun',

--- a/databroker/_drivers/mongo_normalized.py
+++ b/databroker/_drivers/mongo_normalized.py
@@ -112,7 +112,14 @@ class _Entries(collections.abc.Mapping):
                     raise KeyError(f"No run with scan_id={N}")
         if run_start_doc is None:
             raise KeyError(name)
-        return self._doc_to_entry(run_start_doc)
+        entry = self._doc_to_entry(run_start_doc)
+        # The user has requested one specific Entry. In order to give them a
+        # more useful object, 'get' the Entry for them. Note that if they are
+        # expecting an Entry and try to call ``()`` or ``.get()``, that will
+        # still work because BlueskyRun supports those methods and will just
+        # return itself.
+        return entry.get()  # an instance of BlueskyRun
+
 
     def __contains__(self, key):
         # Avoid iterating through all entries.

--- a/databroker/core.py
+++ b/databroker/core.py
@@ -497,7 +497,7 @@ class RemoteBlueskyRun(intake.catalog.base.RemoteCatalog):
         try:
             start = self.metadata['start']
             stop = self.metadata['stop']
-            out = (f"Run Catalog\n"
+            out = (f"BlueskyRun\n"
                    f"  uid={start['uid']!r}\n"
                    f"  exit_status={stop.get('exit_status')!r}\n"
                    f"  {_ft(start['time'])} -- {_ft(stop.get('time', '?'))}\n"

--- a/databroker/core.py
+++ b/databroker/core.py
@@ -666,25 +666,25 @@ class BlueskyRun(intake.catalog.Catalog):
                 getshell=True,
                 catalog=self)
 
-    def get(self):
+    def get(self, *args, **kwargs):
         """
-        Return self.
+        Return self or, if args are provided, some new instance of type(self).
 
         This is here so that the user does not have to remember whether a given
         variable is a BlueskyRun or an *Entry* with a Bluesky Run. In either
         case, ``obj.get()`` will return a BlueskyRun.
         """
-        return self
+        return self._entry.get(*args, **kwargs)
 
-    def __call__(self):
+    def __call__(self, *args, **kwargs):
         """
-        Return self.
+        Return self or, if args are provided, some new instance of type(self).
 
         This is here so that the user does not have to remember whether a given
         variable is a BlueskyRun or an *Entry* with a Bluesky Run. In either
         case, ``obj()`` will return a BlueskyRun.
         """
-        return self.get()
+        return self.get(*args, **kwargs)
 
     def __getattr__(self, key):
         try:

--- a/databroker/core.py
+++ b/databroker/core.py
@@ -666,6 +666,28 @@ class BlueskyRun(intake.catalog.Catalog):
                 getshell=True,
                 catalog=self)
 
+    def get(self):
+        """
+        Return self.
+
+        This is here so that the user does not have to remember whether a given
+        variable is a BlueskyRun or an *Entry* with a Bluesky Run. In either
+        case, ``obj.get()`` will return a BlueskyRun.
+        """
+        return self
+
+    def __call__(self):
+        """
+        Return self.
+
+        This is here so that the user does not have to remember whether a given
+        variable is a BlueskyRun or an *Entry* with a Bluesky Run. In either
+        case, ``obj()`` will return a BlueskyRun.
+        """
+        return self.get()
+
+    def __getattr__(self, key):
+        return getattr(self._entry, key)
 
     def canonical(self, *, fill):
         """

--- a/databroker/core.py
+++ b/databroker/core.py
@@ -687,7 +687,14 @@ class BlueskyRun(intake.catalog.Catalog):
         return self.get()
 
     def __getattr__(self, key):
-        return getattr(self._entry, key)
+        try:
+            # Let the base classes try to handle it first. This will handle,
+            # for example, accessing subcatalogs using dot-access.
+            return super().__getattr__(key)
+        except AttributeError:
+            # The user might be trying to access an Entry method. Try that
+            # before giving up.
+            return getattr(self._entry, key)
 
     def canonical(self, *, fill):
         """

--- a/databroker/in_memory.py
+++ b/databroker/in_memory.py
@@ -7,7 +7,7 @@ import intake.source.base
 from mongoquery import Query
 
 
-from .core import parse_handler_registry, discover_handlers
+from .core import parse_handler_registry, discover_handlers, Entry
 from .v2 import Broker
 
 
@@ -62,7 +62,7 @@ class BlueskyInMemoryCatalog(Broker):
         uid = start_doc['uid']
         self._uid_to_run_start_doc[uid] = start_doc
 
-        entry = SafeLocalCatalogEntry(
+        entry = Entry(
             name=start_doc['uid'],
             description={},  # TODO
             driver='databroker.core.BlueskyRunFromGenerator',

--- a/databroker/in_memory.py
+++ b/databroker/in_memory.py
@@ -11,14 +11,6 @@ from .core import parse_handler_registry, discover_handlers, Entry
 from .v2 import Broker
 
 
-class SafeLocalCatalogEntry(intake.catalog.local.LocalCatalogEntry):
-    # For compat with intake 0.5.1.
-    # Not necessary after https://github.com/intake/intake/pull/362
-    # is released.
-    def describe(self):
-        return copy.deepcopy(super().describe())
-
-
 class BlueskyInMemoryCatalog(Broker):
     name = 'bluesky-run-catalog'  # noqa
 

--- a/databroker/in_memory.py
+++ b/databroker/in_memory.py
@@ -149,7 +149,13 @@ class BlueskyInMemoryCatalog(Broker):
                         break
                 else:
                     raise KeyError(f"No run with scan_id={N}")
-        return self._entries[uid]
+        entry = self._entries[uid]
+        # The user has requested one specific Entry. In order to give them a
+        # more useful object, 'get' the Entry for them. Note that if they are
+        # expecting an Entry and try to call ``()`` or ``.get()``, that will
+        # still work because BlueskyRun supports those methods and will just
+        # return itself.
+        return entry.get()  # an instance of BlueskyRun
 
     def __len__(self):
         return len(self._uid_to_run_start_doc)

--- a/databroker/tests/test_v2/generic.py
+++ b/databroker/tests/test_v2/generic.py
@@ -191,6 +191,12 @@ def test_read(bundle):
     entry().to_dask().load()
 
 
+def test_dot_access(bundle):
+    run = bundle.cat['xyz']()[bundle.uid]()
+    entry = run['primary']
+    entry = getattr(run, 'primary')
+
+
 def test_include_and_exclude(bundle):
     run = bundle.cat['xyz']()[bundle.uid]()
     entry = run['primary']


### PR DESCRIPTION
This is an experimental idea that I would like to _try_ in databroker. If we find that it creates more confusion than it alleviates, we should revert it before the `databroker.v2` interface is declared "stable for general users". If we find that it works well, we should explore moving it upstream to intake if @martindurant is game. (Martin, your comments on what follows are welcome here too!)

## Background and Motivation

To help users who don't have a complete mental model of intake, intake overrides `__getattr__` to blur the line between an Entry and its content. If I call `entry.<something>` when I mean `entry.get().<something>` intake will "do the right thing." Thus, I can get along not really understanding the entry/content distinction and sometimes I'm OK. But other times I can't help but bump into it. For example, this returns an `Entry`.

```py
catalog['1a86d0']
```

(And the same with our custom recency-based lookup, such as the ubiquitous `catalog[-1]`.)

Now, sometimes having an Entry is useful. I can, for example, obtain some metadata cheaply. This is typically useful in loops over large numbers of entries

```py
for key, entry in  catalog.items():
    populate_some_gui(entry.describe())
```

but when I look up a specific item via `__getitem__`, as in `catalog['1a86d0']`, what I typically want is its _content_ so I can see a nice repr and, if it's a sub-catalog, iterate over its contents. I can't do that to an Entry. I have to access the Entry's content via one of these:

```py
catalog['1a86d0'].get()
catalog['1a86d0']()
```
...which is not so obvious to our users or nice to look at. Now, if I use dot-access on it directly

```py
catalog['1a87d0'].primary.read()
```

intake automatically makes that into `catalog['1a87d0'].get().primary.get().read()`. But this doesn't help me when I want to stop at `catalog['1a87d0']` and examine it. Early feedback with our users has shown this is a major sticking point.

## Proposed Change

Above we said that the magic transforming "`.` -> `.get()`" blurs the line between an Entry and its content. Notice that it only does so in one direction. If I have an Entry, I can treat it like its content, and it will do the right thing.

```py
catalog['1a87d0'].get().primary
catalog['1a87d0'].primary  # Treating an Entry as if it were its content works.
```

But if I have an Entry's _content_ and I try to treat it like an Entry, that fails.

```py
catalog['1a87d0'].describe()  # works
catalog['1a87d0'].get().describe()  # FAILS! Can't treat content like an Entry
```

In this PR, we make that last line work. The blurriness between Entry and content now works in _both_ directions instead of only one. That is, `entry.get().<something>` falls back to `entry.<something>`, symmetric with how, `entry.<something>` falls back to `entry.get().<something>`.

This makes it possible to address the usability issue that proved to be a sticking point with our early users. Now, `__getitem__` on our Catalogs returns `entry.get()` instead of `entry` so that

```py
catalog['1a86d0']
```

returns content (a `BlueskyRun`) with a nice repr that you can iterate over. Note that `catalog.items()` still returns `(key, Entry)` pairs; the laziness of `Entry` is still accessible when you need it.

This _could_ turn out to be a terrible idea. It is certainly very magical and could leave users confused about the type of the object that they are holding. But I would argue that, if we have accepted the magical ~`__getitem__`~ `__getattr__` [edited] behavior in one direction, it is _less_ confusing to have it in both directions. At any rate it's worth trying in the wild.

Thanks to @tacaswell for helping me think this through.