### PR TITLE
Compat with event-model 1.12.0

### DIFF
--- a/databroker/tests/test_broker.py
+++ b/databroker/tests/test_broker.py
@@ -551,7 +551,8 @@ def test_handler_options(db, RE, hw):
     h = db[rs_uid]
 
     # Clear the handler registry. We'll reinstate the relevant handler below.
-    db.reg.handler_reg.clear()
+    for spec in list(db.reg.handler_reg):
+        db.reg.deregister_handler(spec)
 
     # Get unfilled event.
     ev, ev2 = db.get_events(h, fields=['img'])

--- a/databroker/v1.py
+++ b/databroker/v1.py
@@ -58,20 +58,11 @@ class Registry:
         return self._catalog.filler.root_map
 
     def register_handler(self, key, handler, overwrite=False):
-        if (not overwrite) and (key in self.handler_reg):
-            if self.handler_reg[key] is handler:
-                return
-            raise self.DuplicateHandler(
-                "You are trying to register a second handler "
-                "for spec {}, {}".format(key, self))
-
-        self.deregister_handler(key)
-        self.handler_reg[key] = handler
+        return self._catalog.filler.register_handler(
+            key, handler, overwrite=overwrite)
 
     def deregister_handler(self, key):
-        handler = self.handler_reg.pop(key, None)
-        # TODO Filler should support explicit de-registration that clears
-        # the relevant caches.
+        return self._catalog.filler.deregister_handler(key)
 
     def copy_files(self, resource, new_root,
                    verify=False, file_rename_hook=None):

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 boltons
 dask[array,bag]
 doct
-event-model >=1.11.1b1
+event-model >=1.12.0
 humanize
 intake >=0.5.2  # first release to use entrypoints
 jinja2


### PR DESCRIPTION
The ``Filler.handler_registry`` is not mutable in event-model 1.12.0.

Our nightly Travis builds have been failing ever since event-model 1.12.0 was
released.