### PR TITLE
Fix typo in EntrypointsCatalog

### DIFF
--- a/databroker/discovery.py
+++ b/databroker/discovery.py
@@ -53,7 +53,7 @@ class EntrypointsCatalog(Catalog):
             try:
                 self._entries[name] = EntrypointEntry(entrypoint)
             except Exception as e:
-                warings.warn(f"Failed to load {name}, {entrypoint}, {e!r}.")
+                warnings.warn(f"Failed to load {name}, {entrypoint}, {e!r}.")
 
 
 class V0Entry(CatalogEntry):


### PR DESCRIPTION
Found a very small typo in discovery.py. 

I investigated adding a pytest to stress this code, but not sure how to setup entry points in a test.