### PR TITLE
Fix uid regex

### DIFF
--- a/databroker/_core.py
+++ b/databroker/_core.py
@@ -792,7 +792,7 @@ def _(key, db):
     if not results:
         # No dice? Try searching as if we have a partial uid.
         logger.debug('Treating %s as a partial uuid' % key)
-        gen = db.hs.find_run_starts(uid={'$regex': '{0}.*'.format(key)})
+        gen = db.hs.find_run_starts(uid={'$regex': '^{0}'.format(key)})
         results = list(gen)
     if not results:
         # Still no dice? Bail out.

--- a/databroker/_drivers/mongo_normalized.py
+++ b/databroker/_drivers/mongo_normalized.py
@@ -73,7 +73,7 @@ class _Entries(collections.abc.Mapping):
             if run_start_doc is None:
                 regex_query = {
                     '$and': [self.catalog._query,
-                             {'uid': {'$regex': f'{name}.*'}}]}
+                             {'uid': {'$regex': f'^{name}'}}]}
                 matches = list(collection.find(regex_query).limit(10))
                 if not matches:
                     raise KeyError(name)

--- a/databroker/tests/test_broker.py
+++ b/databroker/tests/test_broker.py
@@ -19,6 +19,8 @@ import copy
 import pytest
 import six
 import numpy as np
+import event_model
+
 from databroker._core import DOCT_NAMES
 
 if sys.version_info >= (3, 5):
@@ -242,6 +244,23 @@ def test_partial_uid_lookup(db, RE, hw):
         # Some letter will happen to be the first letter of more than one uid.
         for first_letter in string.ascii_lowercase:
             db[first_letter]
+
+
+def test_partial_uid_lookup2(db):
+    key_parts = ['a'*6, 'b'*6]
+
+    run_bundle_A = event_model.compose_run(uid=''.join(key_parts))
+    db.insert('start', run_bundle_A.start_doc)
+    db.insert('stop', run_bundle_A.compose_stop())
+    run_bundle_B = event_model.compose_run(uid=''.join(key_parts[::-1]))
+    db.insert('start', run_bundle_B.start_doc)
+    db.insert('stop', run_bundle_B.compose_stop())
+
+    hA = db[key_parts[0]]
+    assert dict(hA.start) == run_bundle_A.start_doc
+
+    hB = db[key_parts[1]]
+    assert dict(hB.start) == run_bundle_B.start_doc
 
 
 def test_find_by_float_time(db_empty, RE, hw):

--- a/databroker/tests/utils.py
+++ b/databroker/tests/utils.py
@@ -5,8 +5,7 @@ import shutil
 import tempfile
 import time
 import uuid
-
-import mongobox
+import pytest
 import ophyd.sim
 import tzlocal
 
@@ -37,6 +36,7 @@ def build_intake_jsonl_backed_broker(request):
 
 
 def build_intake_mongo_backed_broker(request):
+    mongobox = pytest.importorskip('mongobox')
     box = mongobox.MongoBox()
     box.start()
     client = box.client()
@@ -53,7 +53,9 @@ def build_intake_mongo_backed_broker(request):
         handler_registry={'NPY_SEQ': ophyd.sim.NumpySeqHandler})
     return broker.v1
 
+
 def build_intake_mongo_embedded_backed_broker(request):
+    mongobox = pytest.importorskip('mongobox')
     tmp_dir = tempfile.TemporaryDirectory()
     tmp_path = tmp_dir.name
     catalog_path = Path(tmp_path) / 'catalog.yml'


### PR DESCRIPTION
This is apparently a long standing bug!  The old rule would match the prefix anywhere, the new rule matches it only at the beginning.