### PR TITLE
Reinstate reentrant fill pattern.

### DIFF
--- a/databroker/core.py
+++ b/databroker/core.py
@@ -371,15 +371,17 @@ def unfilled_partitions(start, descriptors, resources, stop, datum_gens,
     partition.append(('stop', stop))
     yield partition
 
+
 def fill(
     filler,
     event,
     lookup_resource_for_datum,
     get_resource,
     get_datum_pages,
-    last_datum_id=None):
+    last_datum_id=None,
+):
     try:
-        _, filled_event = filler('event', event)
+        _, filled_event = filler("event", event)
         return filled_event
     except event_model.UnresolvableForeignKeyError as err:
         datum_id = err.key
@@ -389,16 +391,27 @@ def fill(
             # work. We are in an infinite loop. Bail!
             raise
 
-        if '/' in datum_id:
-            resource_uid, _ = datum_id.split('/', 1)
+        # try to fast-path looking up the resource uid if this works
+        # it saves us a a database hit (to get the datum document)
+        if "/" in datum_id:
+            resource_uid, _ = datum_id.split("/", 1)
+        # otherwise do it the standard way
         else:
             resource_uid = lookup_resource_for_datum(datum_id)
 
-        resource = get_resource(uid=resource_uid)
-        filler('resource', resource)
+        # but, it might be the case that the key just happens to have
+        # a '/' in it and it does not have any semantic meaning so we
+        # optimistically try
+        try:
+            resource = get_resource(uid=resource_uid)
+        # and then fall back to the standard way to be safe
+        except ValueError:
+            resource = get_resource(lookup_resource_for_datum(datum_id))
+
+        filler("resource", resource)
         # Pre-fetch all datum for this resource.
         for datum_page in get_datum_pages(resource_uid=resource_uid):
-            filler('datum_page', datum_page)
+            filler("datum_page", datum_page)
         # TODO -- When to clear the datum cache in filler?
 
         # Re-enter and try again now that the Filler has consumed the
@@ -406,8 +419,13 @@ def fill(
         # Event document (hence this re-entrant structure) or might be good
         # to go.
         return fill(
-            filler, event, lookup_resource_for_datum, get_resource,
-            get_datum_pages, last_datum_id=datum_id)
+            filler,
+            event,
+            lookup_resource_for_datum,
+            get_resource,
+            get_datum_pages,
+            last_datum_id=datum_id,
+        )
 
 
 def documents_to_xarray(*, start_doc, stop_doc, descriptor_docs,


### PR DESCRIPTION
This pattern was stripped out at some point between 1.0.0b3 and current
`master`, and it should not have been. It handles the possibility that one
Event could have multiple datum_ids in it, and thus may need to take more than
one trip through the `try...except UnresolvableForeignKeyError` dance to pull
all the relevant Datum documents.

We should also add a test, but I'm inclined to merge this as a hot fix and open
a separate issue for protecting it with a test. Verified interactively at CHX:

Before:

```py
import databroker
catalog = databroker.catalog.chx
run = catalog['d6013efc']
run
run.primary.to_dask()  # raises UnresolvableForeignKeyError
run.primary.to_dask()  # works
```

After:

```py
import databroker
catalog = databroker.catalog.chx
run = catalog['d6013efc']
run
run.primary.to_dask()  # works
```