### PR TITLE
WIP: Allow user to pass options to pymongo find.

### DIFF
--- a/databroker/tests/test_v2/test_mongo_normalized.py
+++ b/databroker/tests/test_v2/test_mongo_normalized.py
@@ -1,4 +1,5 @@
 import intake
+from intake.catalog.utils import RemoteCatalogError
 from suitcase.mongo_normalized import Serializer
 import os
 import pytest
@@ -64,3 +65,25 @@ sources:
                                  uid=uid,
                                  docs=docs,
                                  remote=remote)
+
+
+# Driver-specific tests
+
+def test_find_kwargs(bundle):
+    "Test that options for search and passed through to pymongo."
+    cat = bundle.cat
+
+    # Pass in a valid argument.
+    results = cat['xyz'].search({'plan_name': 'scan'},
+                                no_cursor_timeout=True)
+    list(results)  # needed to trigger Cursor instantiation in local case
+
+    # Pass in an invalid argument and verify that it raises.
+    if bundle.remote:
+        expected_error = RemoteCatalogError
+    else:
+        expected_error = TypeError
+    with pytest.raises(expected_error):
+        results = cat['xyz'].search({'plan_name': 'scan'},
+                                    NOT_A_VALID_PARAMETER=None)
+        list(results)  # needed to trigger Cursor instantiation in local case


### PR DESCRIPTION
One option of interest is `no_cursor_timeout`. I believe the cursor timeouts
were encountered at XPD or PDF (by @tacaswell? or @mrakitin?). I just
encountered them while trying to do a long export task at FXI.

I think we ought to leave timeouts on by default---they are there for a reason---
but we clearly need the ability to request a timeout-free cursor for the
server for some cases.

This should be documented and tested before being merged.