### PR TITLE
FIX: support dask < 2

### DIFF
--- a/databroker/core.py
+++ b/databroker/core.py
@@ -1329,7 +1329,11 @@ def _transpose(in_data, keys, field):
         for k in keys:
             out[k][j] = dd[k]
     for k in keys:
-        out[k] = dask.array.stack(out[k])
+        # compatibility with dask < 2
+        if hasattr(out[k][0], 'shape'):
+            out[k] = dask.array.stack(out[k])
+        else:
+            out[k] = dask.array.array(out[k])
     return out
 
 


### PR DESCRIPTION
Trying to stack a list of scalars can cause dask to fail on old
versions of dask (this was fixed in dask 2.0).