### PR TITLE
Put lower bound on numpy in tests.

### DIFF
--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -7,6 +7,7 @@ glueviz
 intake[server]
 matplotlib
 mongobox
+numpy >=1.16.0  # for astropy (via glueviz)
 ophyd
 pathlib
 pyqt5

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -10,7 +10,7 @@ mongobox
 numpy >=1.16.0  # for astropy (via glueviz)
 ophyd
 pathlib
-pyqt5
+pyqt5 !=5.14.1
 pytest >=4.4
 pytest-rerunfailures
 pytest-env


### PR DESCRIPTION
Fixes failures like this one:

<details>

```
______________________________ test_glue[sqlite] _______________________________
db = <databroker._core.Broker object at 0x7f337c3372e8>
RE = <bluesky.run_engine.RunEngine object at 0x7f337c1ba080>
    def test_glue(db, RE):
>       from databroker.glue import read_header
databroker/tests/test_glue.py:6:
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
databroker/glue.py:3: in <module>
    from glue.core.data import Data
../../../virtualenv/python3.7.1/lib/python3.7/site-packages/glue/core/__init__.py:3: in <module>
    from .command import Command, CommandStack  # noqa
../../../virtualenv/python3.7.1/lib/python3.7/site-packages/glue/core/command.py:8: in <module>
    from glue.core.data_factories import load_data
../../../virtualenv/python3.7.1/lib/python3.7/site-packages/glue/core/data_factories/__init__.py:3: in <module>
    from .astropy_table import *  # noqa
../../../virtualenv/python3.7.1/lib/python3.7/site-packages/glue/core/data_factories/astropy_table.py:6: in <module>
    from glue.core.data_factories.helpers import has_extension
../../../virtualenv/python3.7.1/lib/python3.7/site-packages/glue/core/data_factories/helpers.py:31: in <module>
    from glue.core.data import Component, BaseData, Data
../../../virtualenv/python3.7.1/lib/python3.7/site-packages/glue/core/data.py:30: in <module>
    from glue.core.coordinates import Coordinates
../../../virtualenv/python3.7.1/lib/python3.7/site-packages/glue/core/coordinates.py:7: in <module>
    from astropy.wcs import WCS
../../../virtualenv/python3.7.1/lib/python3.7/site-packages/astropy/__init__.py:123: in <module>
    _check_numpy()
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
    def _check_numpy():
        """
        Check that Numpy is installed and it is of the minimum version we
        require.
        """
        # Note: We could have used distutils.version for this comparison,
        # but it seems like overkill to import distutils at runtime.
        requirement_met = False
        import_fail = ''
        try:
            import numpy
        except ImportError:
            import_fail = 'Numpy is not installed.'
        else:
            from .utils import minversion
            requirement_met = minversion(numpy, __minimum_numpy_version__)

        if not requirement_met:
            msg = (f"Numpy version {__minimum_numpy_version__} or later must "
                   f"be installed to use Astropy. {import_fail}")
>           raise ImportError(msg)
E           ImportError: Numpy version 1.16.0 or later must be installed to use Astropy.
../../../virtualenv/python3.7.1/lib/python3.7/site-packages/astropy/__init__.py:118: ImportError
```

</details>