### PR TITLE
BlueskyRun._load() optimization

### DIFF
--- a/databroker/core.py
+++ b/databroker/core.py
@@ -962,6 +962,11 @@ class BlueskyRun(intake.catalog.Catalog):
         descriptors_by_name = collections.defaultdict(list)
         for doc in self._descriptors:
             descriptors_by_name[doc.get('name', 'primary')].append(doc)
+        # We employ OrderedDict in several places in this loop. The motivation
+        # is to speed up dask tokenization. When task tokenizes a plain dict,
+        # it sorted the keys, and it turns out that this sort operation
+        # dominates the call time, even for very small dicts. Using an
+        # OrderedDict steers dask toward a different and faster tokenization.
         for stream_name, descriptors in descriptors_by_name.items():
             meta=OrderedDict({'start': self.metadata['start'],
                               'stop': self.metadata['stop'],

--- a/databroker/core.py
+++ b/databroker/core.py
@@ -27,10 +27,6 @@ from .intake_xarray_core.base import DataSourceMixin
 from .intake_xarray_core.xarray_container import RemoteXarray
 from collections import deque
 from dask.base import normalize_token
-from typing import Iterator, Mapping, TypeVar
-
-K = TypeVar("K")
-V = TypeVar("V")
 
 
 class NotMutable(Exception):
@@ -106,6 +102,7 @@ class Entry(intake.catalog.local.LocalCatalogEntry):
         # enables the driver instance to know which Entry created it.
         open_args['entry'] = self
         return plugin, open_args
+
 
 def tail(filename, n=1, bsize=2048):
     """d V might as w
@@ -433,14 +430,12 @@ def unfilled_partitions(start, descriptors, resources, stop, datum_gens,
     yield partition
 
 
-def fill(
-    filler,
-    event,
-    lookup_resource_for_datum,
-    get_resource,
-    get_datum_pages,
-    last_datum_id=None,
-):
+def fill(filler,
+         event,
+         lookup_resource_for_datum,
+         get_resource,
+         get_datum_pages,
+         last_datum_id=None):
     try:
         _, filled_event = filler("event", event)
         return filled_event

--- a/databroker/core.py
+++ b/databroker/core.py
@@ -94,7 +94,7 @@ class Entry(intake.catalog.local.LocalCatalogEntry):
 
 
 def tail(filename, n=1, bsize=2048):
-    """d V might as w
+    """
     Returns a generator with the last n lines of a file.
 
     Thanks to Martijn Pieters for this solution:
@@ -589,7 +589,7 @@ def documents_to_xarray(*, start_doc, stop_doc, descriptor_docs,
             else:
                 keys = scoped_data_keys
             for key, scoped_key in keys.items():
-                field_metadescriptorata = data_keys[key]
+                field_metadata = data_keys[key]
                 field_metadata = data_keys[key]
                 ndim = len(field_metadata['shape'])
                 # if the EventDescriptor doesn't provide names for the
@@ -908,7 +908,6 @@ class BlueskyRun(intake.catalog.Catalog):
             out = f"<Intake catalog: Run *REPR_RENDERING_FAILURE* {exc!r}>"
         return out
 
-    @timeit
     def _load(self):
         # Count the total number of documents in this run.
         self._run_start_doc = Start(self._transforms['start'](self._get_run_start()))

--- a/databroker/core.py
+++ b/databroker/core.py
@@ -968,10 +968,10 @@ class BlueskyRun(intake.catalog.Catalog):
         # dominates the call time, even for very small dicts. Using an
         # OrderedDict steers dask toward a different and faster tokenization.
         for stream_name, descriptors in descriptors_by_name.items():
-            meta=OrderedDict({'start': self.metadata['start'],
-                              'stop': self.metadata['stop'],
-                              'descriptors': descriptors,
-                              'resources': self._resources})
+            metadata = OrderedDict({'start': self.metadata['start'],
+                                    'stop': self.metadata['stop'],
+                                    'descriptors': descriptors,
+                                    'resources': self._resources})
             args = OrderedDict(
                 stream_name=stream_name,
                 get_run_stop=self._get_run_stop,
@@ -983,7 +983,7 @@ class BlueskyRun(intake.catalog.Catalog):
                 get_datum_pages=self._get_datum_pages,
                 fillers=OrderedDict(self.fillers),
                 transforms=OrderedDict(self._transforms),
-                metadata=meta)
+                metadata=metadata)
             self._entries[stream_name] = StreamEntry(
                 name=stream_name,
                 description={},  # TODO
@@ -991,7 +991,7 @@ class BlueskyRun(intake.catalog.Catalog):
                 direct_access='forbid',
                 args=args,
                 cache=None,  # What does this do?
-                metadata=meta,
+                metadata=metadata,
                 catalog_dir=None,
                 getenv=True,
                 getshell=True,

--- a/databroker/core.py
+++ b/databroker/core.py
@@ -29,23 +29,10 @@ from collections import deque, OrderedDict
 from dask.base import normalize_token
 from intake.utils import DictSerialiseMixin
 
-import time
-
-def timeit(f):
-    def wrap(*args):
-        time1 = time.time()
-        ret = f(*args)
-        time2 = time.time()
-        print('{:s} function took {:.3f} ms'.format(f.__name__, (time2-time1)*1000.0))
-        return ret
-    return wrap
-
-class NotMutable(Exception):
-     ...
-
 
 class Document(dict):
     ...
+
 
 @normalize_token.register(Document)
 def tokenize_dict(instance):

--- a/databroker/core.py
+++ b/databroker/core.py
@@ -1,5 +1,4 @@
 import collections
-import copy
 import entrypoints
 import event_model
 from datetime import datetime
@@ -36,7 +35,7 @@ class Document(dict):
 
 @normalize_token.register(Document)
 def tokenize_dict(instance):
-        return instance.__dask_tokenize__()
+    return instance.__dask_tokenize__()
 
 
 class Start(Document):
@@ -81,6 +80,7 @@ class DatumPage(Document):
 
 class PartitionIndexError(IndexError):
     ...
+
 
 class Entry(intake.catalog.local.LocalCatalogEntry):
     def __init__(self, **kwargs):
@@ -1169,8 +1169,8 @@ class BlueskyEventStream(DataSourceMixin):
 
         self._run_stop_doc = metadata['stop']
         self._run_start_doc = metadata['start']
-        self._descriptors =  [descriptor for descriptor in metadata['descriptors']
-                              if descriptor.get('name') == self._stream_name]
+        self._descriptors = [descriptor for descriptor in metadata['descriptors']
+                             if descriptor.get('name') == self._stream_name]
         # Should figure out a way so that self._resources doesn't have to be
         # all of the Run's resources.
         self._resources = metadata['resources']

--- a/databroker/core.py
+++ b/databroker/core.py
@@ -963,8 +963,8 @@ class BlueskyRun(intake.catalog.Catalog):
         for doc in self._descriptors:
             descriptors_by_name[doc.get('name', 'primary')].append(doc)
         # We employ OrderedDict in several places in this loop. The motivation
-        # is to speed up dask tokenization. When task tokenizes a plain dict,
-        # it sorted the keys, and it turns out that this sort operation
+        # is to speed up dask tokenization. When dask tokenizes a plain dict,
+        # it sorts the keys, and it turns out that this sort operation
         # dominates the call time, even for very small dicts. Using an
         # OrderedDict steers dask toward a different and faster tokenization.
         for stream_name, descriptors in descriptors_by_name.items():

--- a/databroker/tests/test_v2/transform.py
+++ b/databroker/tests/test_v2/transform.py
@@ -1,4 +1,5 @@
 def transform(doc):
+    doc = dict(doc)
     assert 'test_key' not in doc.keys()
     doc['test_key'] = 'test_value'
     return doc


### PR DESCRIPTION
This was a joint effort from: @tacaswell, @danielballan, and myself. 

Loading runs (BlueskyRun._load()) from a catalog (RSOXS) was taking 200-400ms per run. This was due to the `dask.tokenize` call in intake: https://github.com/intake/intake/blob/master/intake/utils.py#L86

With these changes `BlueskyRuns` are loading in about 20ms

We got rid of some `deepcopy` calls in load, and decided that transforms will be responsible for not mutating the passed in document.

We converted all of the dictionaries in `BlueskyRun` to `OrderedDicts`, so `tokenize` doesn't sort them. `tokenize` spent the majority of its execution time sorting these dictionaries.

Also we register a tokenize method for all Bluesky docs so that they can quickly be tokenized.

We plan to make a PR into intake that helps speed up `tokenize`, while waiting for that PR we made the changes in databroker by creating the class `StreamEntry`, that inherits from `LocalCatalogEntry`, and overrides `__getstate__` of `DictSerialiseMixin`.