### PR TITLE
Cache Entries and DataSources better.

### DIFF
--- a/databroker/core.py
+++ b/databroker/core.py
@@ -110,7 +110,7 @@ class Entry(intake.catalog.local.LocalCatalogEntry):
         self.__cache.clear()
 
     def get(self, **kwargs):
-        token = tokenize(kwargs)
+        token = tokenize(OrderedDict(kwargs))
         try:
             datasource = self.__cache[token]
             logger.debug(

--- a/databroker/core.py
+++ b/databroker/core.py
@@ -942,6 +942,7 @@ class BlueskyRun(intake.catalog.Catalog):
         return out
 
     def _load(self):
+        print('BlueskyRun._load')
         self._run_start_doc = Start(self._transforms['start'](self._get_run_start()))
         self._descriptors = [Descriptor(self._transforms['descriptor'](descriptor))
                              for descriptor in self._get_event_descriptors()]

--- a/databroker/core.py
+++ b/databroker/core.py
@@ -107,7 +107,7 @@ class Entry(intake.catalog.local.LocalCatalogEntry):
         except TypeError:
             # The lru_cache cannot help us if one of the user parameters
             # is not hashable.
-            return self.get(**kwargs)
+            return super().get(**kwargs)
 
 
 class StreamEntry(intake.catalog.local.LocalCatalogEntry):

--- a/databroker/core.py
+++ b/databroker/core.py
@@ -108,7 +108,6 @@ class Entry(intake.catalog.local.LocalCatalogEntry):
             # The lru_cache cannot help us if one of the user parameters
             # is not hashable.
             return self.get(**kwargs)
-        return super().get(**kwargs)
 
 
 class StreamEntry(intake.catalog.local.LocalCatalogEntry):

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 boltons
+cachetools
 dask[array,bag]
 doct
 event-model >=1.13.0b4


### PR DESCRIPTION
~This is stale work (from November) which may be the complete wrong approach. I am opening this PR to make the work more easily visible.~

This has evolved and now seems like the correct approach. Example with DEBUG logging turned up:

When a file-based ("in-memory") catalog is instantiated, it creates all of its entries greedily. We see that logged here.
```py
In [1]: catalog = BlueskyMsgpackCatalog(f'{directory}/*.msgpack')                                                                                
Created Entry named '35fb6cca-846b-4bbf-9f68-8b01f9c75503'
Created Entry named '7711ad85-43d1-4777-b1f9-e7d581a1057c'
```

When we access a given run for the first time, BlueskyRun (or a sublcass of it, in this case) is instantiated and, as part of that, the data is loaded.

```py
In [2]: catalog['7711ad'];                                                                                                                                                                    
Loaded BlueskyRunFromGenerator named '7711ad85-43d1-4777-b1f9-e7d581a1057c'
Created BlueskyRunFromGenerator named '7711ad85-43d1-4777-b1f9-e7d581a1057c'
```

That instance is cached on the Entry object and retrieved whenever we access it again.

```py
In [3]: catalog['7711ad'];                                                                                                                                                                    
Entry cache found BlueskyRunFromGenerator named '7711ad85-43d1-4777-b1f9-e7d581a1057c'

In [4]: catalog['7711ad'];                                                                                                                                                                    
Entry cache found BlueskyRunFromGenerator named '7711ad85-43d1-4777-b1f9-e7d581a1057c'
```

Accessing a stream causes `_load` to be called again.

```py
In [5]: catalog['7711ad'].primary;                                                                                                                                                            
Entry cache found BlueskyRunFromGenerator named '7711ad85-43d1-4777-b1f9-e7d581a1057c'
Loaded BlueskyRunFromGenerator named '7711ad85-43d1-4777-b1f9-e7d581a1057c'

In [6]: catalog['7711ad'].primary;                                                                                                                                                            
Entry cache found BlueskyRunFromGenerator named '7711ad85-43d1-4777-b1f9-e7d581a1057c'
Loaded BlueskyRunFromGenerator named '7711ad85-43d1-4777-b1f9-e7d581a1057c'
```

Unless it's called successively less than `catalog.ttl` seconds apart (1 second by default).

```py
In [7]: catalog['7711ad'].primary;                                                                                                                                                            
Entry cache found BlueskyRunFromGenerator named '7711ad85-43d1-4777-b1f9-e7d581a1057c'
Loaded BlueskyRunFromGenerator named '7711ad85-43d1-4777-b1f9-e7d581a1057c'

In [8]: catalog['7711ad'].primary;                                                                                                                                                            
Entry cache found BlueskyRunFromGenerator named '7711ad85-43d1-4777-b1f9-e7d581a1057c'
```

Compare this to a Mongo-backed catalog, which does not greedily create Entries:

```py
In [1]: catalog = BlueskyMongoCatalog(mds, fs)  # no log output from Entry.__init__