### PR TITLE
None stop

### DIFF
--- a/databroker/_drivers/mongo_embedded.py
+++ b/databroker/_drivers/mongo_embedded.py
@@ -34,6 +34,8 @@ class _Entries(collections.abc.Mapping):
                 else:
                     return header_doc[field]
             else:
+                if field == 'resources':
+                    return []
                 if field[0:6] == 'count_':
                     return 0
                 else:

--- a/databroker/_drivers/mongo_embedded.py
+++ b/databroker/_drivers/mongo_embedded.py
@@ -36,7 +36,7 @@ class _Entries(collections.abc.Mapping):
             else:
                 if field == 'resources':
                     return []
-                if field[0:6] == 'count_':
+                elif field[0:6] == 'count_':
                     return 0
                 else:
                     return None

--- a/databroker/core.py
+++ b/databroker/core.py
@@ -929,11 +929,16 @@ class BlueskyRun(intake.catalog.Catalog):
     def _load(self):
         # Count the total number of documents in this run.
         self._run_start_doc = Start(self._transforms['start'](self._get_run_start()))
-        self._run_stop_doc = Stop(self._transforms['stop'](self._get_run_stop()))
         self._descriptors = [Descriptor(self._transforms['descriptor'](descriptor))
                              for descriptor in self._get_event_descriptors()]
         self._resources = [Resource(self._transforms['resource'](resource))
-                           for resource in self._get_resources() or []]
+                           for resource in self._get_resources()]
+
+        stop = self._get_run_stop()
+        if stop is None:
+            self._run_stop_doc = stop
+        else:
+            self._run_stop_doc = Stop(self._transforms['stop'](stop))
 
         self.metadata.update({'start': self._run_start_doc})
         self.metadata.update({'stop': self._run_stop_doc})

--- a/databroker/core.py
+++ b/databroker/core.py
@@ -927,13 +927,15 @@ class BlueskyRun(intake.catalog.Catalog):
         return out
 
     def _load(self):
-        # Count the total number of documents in this run.
         self._run_start_doc = Start(self._transforms['start'](self._get_run_start()))
         self._descriptors = [Descriptor(self._transforms['descriptor'](descriptor))
                              for descriptor in self._get_event_descriptors()]
         self._resources = [Resource(self._transforms['resource'](resource))
                            for resource in self._get_resources()]
 
+        # get_run_stop() may return None if the document was never created due
+        # to a critical failure or simply not yet emitted during a Run that is
+        # still in progress. If it returns None, pass that through.
         stop = self._get_run_stop()
         if stop is None:
             self._run_stop_doc = stop
@@ -943,6 +945,7 @@ class BlueskyRun(intake.catalog.Catalog):
         self.metadata.update({'start': self._run_start_doc})
         self.metadata.update({'stop': self._run_stop_doc})
 
+        # Count the total number of documents in this run.
         count = 1
         descriptor_uids = [doc['uid'] for doc in self._descriptors]
         count += len(descriptor_uids)

--- a/databroker/tests/test_v2/test_no_run_stop.py
+++ b/databroker/tests/test_v2/test_no_run_stop.py
@@ -1,0 +1,30 @@
+# This is a special test because we corrupt the generated data.
+# That is why it does not reuse the standard fixures.
+
+import tempfile
+from suitcase.jsonl import Serializer
+from bluesky import RunEngine
+from bluesky.plans import count
+from ophyd.sim import det
+from databroker._drivers.jsonl import BlueskyJSONLCatalog
+
+
+def test_no_stop_document(RE, tmpdir):
+    """
+    When a Run has no RunStop document, whether because it does not exist yet
+    or because the Run was interrupted in a critical way and never completed,
+    we expect the field for 'stop' to contain None.
+    """
+    directory = str(tmpdir)
+
+    serializer = Serializer(directory)
+
+    def insert_all_except_stop(name, doc):
+        if name != 'stop':
+            serializer(name, doc)
+
+    RE(count([det]), insert_all_except_stop)
+    serializer.close()
+    catalog = BlueskyJSONLCatalog(f'{directory}/*.jsonl')
+    assert catalog[-1].metadata['start'] is not None
+    assert catalog[-1].metadata['stop'] is None


### PR DESCRIPTION
While testing at CSX beamline, and looking at a run in progress, with no stop document, this line fails: 
`self._run_stop_doc = Stop(self._transforms['stop'](self._get_run_stop()))`

Also the mongo_embedded get_resources() method should return [] if there are no resources.

Fixes https://github.com/bluesky/databroker/issues/480
Fixes https://github.com/bluesky/databroker/issues/498
