### PR TITLE
Include 'descriptors' in stream metadata.

### DIFF
--- a/databroker/core.py
+++ b/databroker/core.py
@@ -1299,11 +1299,15 @@ class BlueskyEventStream(DataSourceMixin):
     def _load(self):
         # TODO Add driver API to fetch only the descriptors of interest instead
         # of fetching all of them and then filtering.
-        self._descriptors = [Descriptor(self._transforms['descriptor'](descriptor))
-                             for descriptor in self._get_event_descriptors()
-                             if descriptor.get('name') == self._stream_name]
+        self._descriptors = d = [Descriptor(self._transforms['descriptor'](descriptor))
+                                 for descriptor in self._get_event_descriptors()
+                                 if descriptor.get('name') == self._stream_name]
+        self.metadata.update({'descriptors': d})
         # TODO Should figure out a way so that self._resources doesn't have to
         # be all of the Run's resources.
+        # TDOO Should we expose this in metadata as well? Since
+        # _get_resources() only discovers new-style Resources that have a
+        # run_start in them, leave it private for now.
         self._resources = [Resource(self._transforms['resource'](resource))
                            for resource in self._get_resources()]
         

--- a/databroker/core.py
+++ b/databroker/core.py
@@ -1316,10 +1316,9 @@ class BlueskyEventStream(DataSourceMixin):
         # still in progress. If it returns None, pass that through.
         if self._run_stop_doc is None:
             stop = self._get_run_stop()
-            if stop is None:
-                self._run_stop_doc = stop
-            else:
-                self._run_stop_doc = Stop(self._transforms['stop'](stop))
+            if stop is not None:
+                self._run_stop_doc = s = Stop(self._transforms['stop'](stop))
+                self.metadata.update({'stop': s})
         logger.debug(
             "Loaded %s for stream name %r",
             self.__class__.__name__,

--- a/databroker/core.py
+++ b/databroker/core.py
@@ -1291,13 +1291,13 @@ class BlueskyEventStream(DataSourceMixin):
         self._run_stop_doc = metadata['stop']
         self._run_start_doc = metadata['start']
         self._partitions = None
+        self._load_descriptors()
         logger.debug(
             "Created %s for stream name %r",
             self.__class__.__name__,
             self._stream_name)
-        self._load_metadata()
 
-    def _load_metadata(self):
+    def _load_descriptors(self):
         # TODO Add driver API to fetch only the descriptors of interest instead
         # of fetching all of them and then filtering.
         self._descriptors = d = [Descriptor(self._transforms['descriptor'](descriptor))
@@ -1334,7 +1334,6 @@ class BlueskyEventStream(DataSourceMixin):
         return out
 
     def _open_dataset(self):
-        self._load()
         self._ds = documents_to_xarray(
             start_doc=self._run_start_doc,
             stop_doc=self._run_stop_doc,

--- a/databroker/core.py
+++ b/databroker/core.py
@@ -1328,7 +1328,7 @@ class BlueskyEventStream(DataSourceMixin):
     def __repr__(self):
         try:
             out = (f"<Intake catalog: Stream {self._stream_name!r} "
-                   f"from Run {self._get_run_start()['uid'][:8]}...>")
+                   f"from Run {self._run_start_doc['uid'][:8]}...>")
         except Exception as exc:
             out = f"<Intake catalog: Stream *REPR_RENDERING_FAILURE* {exc!r}>"
         return out

--- a/databroker/core.py
+++ b/databroker/core.py
@@ -1295,9 +1295,9 @@ class BlueskyEventStream(DataSourceMixin):
             "Created %s for stream name %r",
             self.__class__.__name__,
             self._stream_name)
-        self._load()
+        self._load_metadata()
 
-    def _load(self):
+    def _load_metadata(self):
         # TODO Add driver API to fetch only the descriptors of interest instead
         # of fetching all of them and then filtering.
         self._descriptors = d = [Descriptor(self._transforms['descriptor'](descriptor))
@@ -1365,7 +1365,7 @@ class BlueskyEventStream(DataSourceMixin):
         return super().to_dask()
 
     def _load_partitions(self, partition_size):
-        self._load()
+        self._load_metadata()
         datum_gens = [self._get_datum_pages(resource['uid'])
                       for resource in self._resources]
         event_gens = [list(self._get_event_pages(descriptor['uid']))

--- a/databroker/core.py
+++ b/databroker/core.py
@@ -1295,6 +1295,7 @@ class BlueskyEventStream(DataSourceMixin):
             "Created %s for stream name %r",
             self.__class__.__name__,
             self._stream_name)
+        self._load()
 
     def _load(self):
         # TODO Add driver API to fetch only the descriptors of interest instead

--- a/databroker/tests/test_v2/generic.py
+++ b/databroker/tests/test_v2/generic.py
@@ -255,3 +255,14 @@ def test_transforms(bundle):
     for name, doc in run.canonical(fill='no'):
         if name in {'start', 'stop', 'resource', 'descriptor'}:
             assert doc.get('test_key') == 'test_value'
+
+
+def test_metadata_keys(bundle):
+    run = bundle.cat['xyz']()[bundle.uid]()
+
+    run_metadata = run.metadata
+    assert 'start' in run_metadata
+    assert 'stop' in run_metadata
+
+    stream_metadata = run['primary']().metadata
+    assert 'descriptors' in stream_metadata


### PR DESCRIPTION
I think the metadata should be initialized at init time. Is there
any harm in calling `_load` there?