### PR TITLE
DOC: correct the archiver doc

### DIFF
--- a/doc/source/v1/archiver.rst
+++ b/doc/source/v1/archiver.rst
@@ -5,25 +5,23 @@
 Connection with Archiver Appliance
 **********************************
 
-The Archiver Appliance is an EPICS logging system developed 
-in a collaboration of SLAC, BNL, and MSU for collecting and 
-storing measurements from various control devices. Data retrieval 
-is based on the client-server interface using HTTP requests. 
-Large-scale accelerators and experimental facilities may maintain 
-multiple archivers. Within the databroker application, each archiver 
-is represented by an ArchiverEventSource that needs to be configured 
-and registred with the Broker. The following sections highlight 
-two major topics: ArchiverEventSource configuration and data retrival 
-based on the databroker interface.
+The Archiver Appliance is an EPICS logging system developed in a collaboration
+of SLAC, BNL, and MSU for collecting and storing measurements from various
+control devices. Data retrieval is based on the client-server interface using
+HTTP requests.  Large-scale accelerators and experimental facilities may
+maintain multiple archivers. Within the databroker application, each archiver
+is represented by an ArchiverEventSource that needs to be configured and
+registred with the Broker. The following sections highlight two major topics:
+ArchiverEventSource configuration and data retrival based on the databroker
+interface.
 
 Configuration
 -------------
 
-ArchiverEventSources is configured via :class:`Broker` by
-extending the databroker configuration file with a list of archiver
-entries. For example, the following cxs_with_archiver.yml file
-illustrates the configuration of two ArchiverEventSources, arch_csx
-and arch_acc:
+ArchiverEventSources is configured via :class:`Broker` by extending the
+databroker configuration file with a list of archiver entries. For example, the
+following ``cxs_with_archiver.yml`` file illustrates the configuration of two
+ArchiverEventSources, ``arch_csx`` and ``arch_acc``:
 
 .. code-block:: yaml
 
@@ -39,12 +37,12 @@ and arch_acc:
  - config:
      name: 'arch_csx'
      url: 'http://xf23id-ca.cs.nsls2.local:17668'
-     timezone: 'US/Eastern' 
+     timezone: 'US/Eastern'
    module: 'databroker.eventsource.archiver'
    class: 'ArchiverEventSource'
 
-According to this file, each ArchiverEventSource is defined 
-with four configuration key-value pairs :
+According to this file, each ArchiverEventSource is defined with four
+configuration key-value pairs :
 
 * name: user-defined name of the Archiver Appliance archiver
 * url: address of the Archiver Appliance Retrieval server
@@ -54,19 +52,18 @@ with four configuration key-value pairs :
 A pvs dictionary can be extended via :class:`Broker` as:
 
 .. code-block:: python
-  
+
    db = Broker.named('csx_with_archivers')
    arch_csx  = db.event_sources_by_name['arch_csx']
-   arch_csx.pvs.update({'pv1':'XF:23ID-ID{BPM}Val:PosXS-I'})
+   arch_csx.pvs.update({'pv1': 'XF:23ID-ID{BPM}Val:PosXS-I'})
 
 
 
-Data Retrieval 
+Data Retrieval
 --------------
 
-After integrating ArchiverEventSources with :class:`Broker`, 
-PV data can be retrieved with the standard :meth:`Header.table` 
-method:
+After integrating ArchiverEventSources with :class:`Broker`, PV data can be
+retrieved with the standard :meth:`Header.table` method:
 
 .. code-block:: python
 
@@ -74,6 +71,4 @@ method:
    hdr = db[69209]
 
    stream_name = 'pv1'
-   df = db.table(stream_name) 	
- 
-
+   df = hdr.table(stream_name=stream_name)


### PR DESCRIPTION
During the use of the example for the archiver appliance at ISS, noticed the example is wrong (should be `hdr.table(...)` rather than `db.table(...)`).

Also, <kbd>G</kbd>+<kbd>Q</kbd>'d the blocks of text.