### PR TITLE
Fix the timezone for the archiver-returned data

### DIFF
--- a/databroker/eventsource/archiver.py
+++ b/databroker/eventsource/archiver.py
@@ -222,10 +222,10 @@ class ArchiverEventSource(object):
         ananos = np.asarray(nanos)
         times = asecs*1.0e+3 + ananos*1.0e-6
 
-        datetimes = pd.to_datetime(times, unit='ms')
+        datetimes = pd.to_datetime(times, unit='ms', utc=True)
 
         df = pd.DataFrame()
-        df['time'] = datetimes
+        df['time'] = datetimes.tz_convert(tz=self.tz)
         df['data'] = data
 
         return df


### PR DESCRIPTION
This is a fix for the returned data from the archiver (`_table_given_times(...)` method), which was originally in the UTC timezone. The problem was observed with the ISS archiver appliance, see https://github.com/elistavitski/profile_sample-environment/blob/master/startup/00-startup.py.

Here are the examples of returns before and after the fix.

Before:
=====
```py
In [1]: import databroker

In [2]: databroker.__version__
Out[2]: '0.13.0'

In [3]: import datetime

In [4]: datetime.datetime.now().isoformat()
Out[4]: '2020-01-28T11:59:09.239276'

In [5]: d = arch_iss.tables_given_times(ttime.time()-1*24*3600, ttime.time())

In [6]: d['rga_ch1'].head()
Out[6]:
                           time          data
0 2020-01-27 16:59:02.682578613  5.822290e-10
1 2020-01-27 17:00:19.692776855  5.677490e-10
2 2020-01-27 17:01:36.703038818  5.634920e-10
3 2020-01-27 17:02:53.213214844  5.597510e-10
4 2020-01-27 17:04:10.223529053  5.709960e-10

In [7]:
```

After:
====
```py
In [1]: import databroker

In [2]: databroker.__version__
Out[2]: '0.13.3+1.g99f26eb'  # the commit for this PR was cherry-picked and applied to v0.13.3 tag to test on the beamline

In [3]: import datetime

In [4]: datetime.datetime.now().isoformat()
Out[4]: '2020-01-28T12:01:06.929273'

In [5]: d = arch_iss.tables_given_times(ttime.time()-1*24*3600, ttime.time())

In [6]: d['rga_ch1'].head()
Out[6]:
                                 time          data
0 2020-01-27 12:00:19.692776855-05:00  5.677490e-10
1 2020-01-27 12:01:36.703038818-05:00  5.634920e-10
2 2020-01-27 12:02:53.213214844-05:00  5.597510e-10
3 2020-01-27 12:04:10.223529053-05:00  5.709960e-10
4 2020-01-27 12:05:27.233862793-05:00  5.828740e-10

In [7]:
```