### PR TITLE
Document mutability cleanup

### DIFF
--- a/databroker/core.py
+++ b/databroker/core.py
@@ -72,7 +72,7 @@ class Document(dict):
     def __setitem__(self, k, v):
         raise NotMutable(self._NOT_MUTABLE_MSG)
 
-    def __delitem__(self, k, v):
+    def __delitem__(self, k):
         raise NotMutable(self._NOT_MUTABLE_MSG)
 
     def pop(self, k):

--- a/databroker/core.py
+++ b/databroker/core.py
@@ -97,7 +97,7 @@ class Document(dict):
         # Convert to dict and then make a deep copy to ensure that if the user
         # mutates any internally nested dicts there is no spooky action at a
         # distance.
-        return copy.deepcopy(self)
+        return copy.deepcopy(dict(self))
 
     def __deepcopy__(self, memo):
         # Without this, copy.deepcopy(Document(...)) fails because deepcopy

--- a/databroker/core.py
+++ b/databroker/core.py
@@ -97,7 +97,14 @@ class Document(dict):
         # Convert to dict and then make a deep copy to ensure that if the user
         # mutates any internally nested dicts there is no spooky action at a
         # distance.
-        return copy.deepcopy(dict(self))
+        return copy.deepcopy(self)
+
+    def __deepcopy__(self, memo):
+        # Without this, copy.deepcopy(Document(...)) fails because deepcopy
+        # creates a new, empty Document instance and then tries to add items to
+        # it.
+        return self.__class__({k: copy.deepcopy(v, memo)
+                              for k, v in self.items()})
 
     def __dask_tokenize__(self):
         raise NotImplementedError

--- a/databroker/core.py
+++ b/databroker/core.py
@@ -78,6 +78,18 @@ class Document(dict):
     def pop(self, k):
         raise NotMutable(self._NOT_MUTABLE_MSG)
 
+    def popitem(self):
+        raise NotMutable(self._NOT_MUTABLE_MSG)
+
+    def clear(self):
+        raise NotMutable(self._NOT_MUTABLE_MSG)
+
+    def setdefault(self, k, v):
+        raise NotMutable(self._NOT_MUTABLE_MSG)
+
+    def update(self, d=None, **kwargs):
+        raise NotMutable(self._NOT_MUTABLE_MSG)
+
     def to_dict(self):
         """
         Create a mutable deep copy.

--- a/databroker/tests/test_document.py
+++ b/databroker/tests/test_document.py
@@ -39,3 +39,13 @@ def test_deep_copy():
     b['x']['y']['z'] = 2
     # Verify original is not modified.
     assert a['x']['y']['z'] == 1
+
+
+def test_to_dict():
+    a = Document({'x': {'y': {'z': 1}}})
+    b = a.to_dict()
+    assert not isinstance(b, Document)
+    assert isinstance(b, dict)
+    b['x']['y']['z'] = 2
+    # Verify original is not modified.
+    assert a['x']['y']['z'] == 1

--- a/databroker/tests/test_document.py
+++ b/databroker/tests/test_document.py
@@ -44,8 +44,7 @@ def test_deep_copy():
 def test_to_dict():
     a = Document({'x': {'y': {'z': 1}}})
     b = a.to_dict()
-    assert not isinstance(b, Document)
-    assert isinstance(b, dict)
+    assert type(b) is dict  # i.e. not Document
     b['x']['y']['z'] = 2
     # Verify original is not modified.
     assert a['x']['y']['z'] == 1

--- a/databroker/tests/test_document.py
+++ b/databroker/tests/test_document.py
@@ -1,0 +1,41 @@
+import copy
+
+import pytest
+
+from ..core import Document, NotMutable
+
+
+def test_immutable():
+    d = Document({'a': 1})
+    with pytest.raises(NotMutable):
+        # Update existing key
+        d['a'] = 2
+    with pytest.raises(NotMutable):
+        # Add new key
+        d['b'] = 2
+    with pytest.raises(NotMutable):
+        d.setdefault('a', 2)
+    with pytest.raises(NotMutable):
+        d.setdefault('b', 2)
+    with pytest.raises(NotMutable):
+        del d['a']
+    with pytest.raises(NotMutable):
+        d.pop('a')
+    with pytest.raises(NotMutable):
+        d.popitem()
+    with pytest.raises(NotMutable):
+        d.clear()
+    with pytest.raises(NotMutable):
+        # Update existing key
+        d.update({'a': 2})
+    with pytest.raises(NotMutable):
+        # Add new key
+        d.update({'b': 2})
+
+
+def test_deep_copy():
+    a = Document({'x': {'y': {'z': 1}}})
+    b = copy.deepcopy(a)
+    b['x']['y']['z'] = 2
+    # Verify original is not modified.
+    assert a['x']['y']['z'] == 1


### PR DESCRIPTION
The tests that _all_ dict methods that would mutate the documents, including lesser-used ones like `popitem`, raise `NotMutable` as they should.

It also allows `copy.deepcopy(Document(...))` to work, whereas on the `master` branch it is necessary to do `copy.deepcopy(dict(Document(...))`.

@tacaswell At some point early on in defining `Document` I floated the idea of a more aggressive override of `__deepcopy__` and you talked me out of it. I forget exactly what I was proposing then, but I think what I've done here is fairly gentle and beneficial. Agree?

This also prompts the question, "What should `Document(...).copy()` do? "Currently we do not override it, so it falls back to `dict.copy()` returns a plain `dict` with a shallow copy of the original `Document`. Recall that we also support `to_dict()` which returns a `dict` with a deep copy. Options I can think of:
* Leave as is.
* Return `self`, since `Document.copy()` might be expected to return a `Document` a "shallow copy of an immutable type" is meaningless.
* Do the same thing as `to_dict()` does. (Invoking a deep copy here seems like it could be surprising though, so probably not a good option).