### PR TITLE
Clean up __repr__s.

### DIFF
--- a/databroker/core.py
+++ b/databroker/core.py
@@ -954,8 +954,8 @@ class RemoteBlueskyRun(intake.catalog.base.RemoteCatalog):
             return f"<{self.__class__.__name__} *REPR RENDERING FAILURE* {exc!r}>"
 
     def _repr_pretty_(self, p, cycle):
-        self._load()
         try:
+            self._load()
             start = self.metadata['start']
             stop = self.metadata['stop']
             out = (f"BlueskyRun\n"
@@ -1069,8 +1069,8 @@ class BlueskyRun(intake.catalog.Catalog):
             return f"<{self.__class__.__name__} *REPR RENDERING FAILURE* {exc!r}>"
 
     def _repr_pretty_(self, p, cycle):
-        self._load()
         try:
+            self._load()
             start = self.metadata['start']
             stop = self.metadata['stop']
             out = (f"BlueskyRun\n"

--- a/databroker/tests/test_v2/generic.py
+++ b/databroker/tests/test_v2/generic.py
@@ -97,14 +97,25 @@ def test_search(bundle):
 
 
 def test_repr(bundle):
-    "Test that custom repr (with run uid) appears."
-    print(bundle.uid)
+    "Test that custom repr (with run uid) appears and is one line only."
     entry = bundle.cat['xyz']()[bundle.uid]
     assert bundle.uid in repr(entry)
     run = entry()
-    print(repr(run))
     assert bundle.uid in repr(run)
-    assert 'primary' in repr(run)
+    assert len(repr(run).splitlines()) == 1
+
+
+def test_repr_pretty(bundle):
+    "Test the IPython _repr_pretty_ has uid and also stream names."
+    formatters = pytest.importorskip("IPython.core.formatters")
+    f = formatters.PlainTextFormatter()
+    entry = bundle.cat['xyz']()[bundle.uid]
+    assert bundle.uid in f(entry)
+    # Stream names should be displayed.
+    assert 'primary' in f(entry)
+    run = entry()
+    assert bundle.uid in f(run)
+    assert 'primary' in f(run)
 
 
 def test_iteration(bundle):


### PR DESCRIPTION
* Use `_repr_pretty_` for any multi-line reprs.
* Consistently use the actual (sub)class name
  (`self.__class__.__name__`) in `__repr__` but use `BlueskyRun` in all
  `_repr_pretty_` to hide the remote vs. local distinction and the
  distinction between `BlueskyRun` and `BlueskyRunFromGenerator`, which
  is not intended to be an end-user-facing distinction.

Closes #532