### PR TITLE
Reduce public API before release.

### DIFF
--- a/databroker/_drivers/jsonl.py
+++ b/databroker/_drivers/jsonl.py
@@ -1,3 +1,4 @@
+import errno
 import glob
 import json
 import os
@@ -5,7 +6,6 @@ import pathlib
 import event_model
 
 from ..in_memory import BlueskyInMemoryCatalog
-from ..core import tail
 
 
 def gen(filename):
@@ -180,3 +180,64 @@ class BlueskyJSONLCatalog(BlueskyInMemoryCatalog):
             return [serializer], []
 
         return RunRouter([factory])
+
+
+def tail(filename, n=1, bsize=2048):
+    """
+    Returns a generator with the last n lines of a file.
+
+    Thanks to Martijn Pieters for this solution:
+    https://stackoverflow.com/a/12295054/6513183
+
+    Parameters
+    ----------
+    filename : string
+    n: int
+        number of lines
+    bsize: int
+        seek step size
+    Returns
+    -------
+    line : generator
+    """
+
+    # get newlines type, open in universal mode to find it
+    with open(filename, 'r', newline=None) as hfile:
+        if not hfile.readline():
+            return  # empty, no point
+        sep = hfile.newlines  # After reading a line, python gives us this
+    assert isinstance(sep, str), 'multiple newline types found, aborting'
+
+    # find a suitable seek position in binary mode
+    with open(filename, 'rb') as hfile:
+        hfile.seek(0, os.SEEK_END)
+        linecount = 0
+        pos = 0
+
+        while linecount <= n + 1:
+            # read at least n lines + 1 more; we need to skip a partial line later on
+            try:
+                hfile.seek(-bsize, os.SEEK_CUR)           # go backwards
+                linecount += hfile.read(bsize).count(sep.encode())  # count newlines
+                hfile.seek(-bsize, os.SEEK_CUR)           # go back again
+            except IOError as e:
+                if e.errno == errno.EINVAL:
+                    # Attempted to seek past the start, can't go further
+                    bsize = hfile.tell()
+                    hfile.seek(0, os.SEEK_SET)
+                    pos = 0
+                    linecount += hfile.read(bsize).count(sep.encode())
+                    break
+                raise  # Some other I/O exception, re-raise
+            pos = hfile.tell()
+
+    # Re-open in text mode
+    with open(filename, 'r') as hfile:
+        hfile.seek(pos, os.SEEK_SET)  # our file position from above
+        for line in hfile:
+            # We've located n lines *or more*, so skip if needed
+            if linecount > n:
+                linecount -= 1
+                continue
+            # The rest we yield
+            yield line.rstrip()

--- a/databroker/core.py
+++ b/databroker/core.py
@@ -15,7 +15,6 @@ import cachetools
 from dask.base import tokenize
 import intake.catalog.base
 import intake.catalog.local
-import errno
 import intake.container.base
 from intake.compat import unpack_kwargs
 import msgpack
@@ -254,67 +253,6 @@ class StreamEntry(Entry):
                               if isinstance(arg, DictSerialiseMixin) else arg
                               for k, arg in self._captured_init_kwargs.items()})
         return OrderedDict(cls=self.classname, args=args, kwargs=kwargs)
-
-
-def tail(filename, n=1, bsize=2048):
-    """
-    Returns a generator with the last n lines of a file.
-
-    Thanks to Martijn Pieters for this solution:
-    https://stackoverflow.com/a/12295054/6513183
-
-    Parameters
-    ----------
-    filename : string
-    n: int
-        number of lines
-    bsize: int
-        seek step size
-    Returns
-    -------
-    line : generator
-    """
-
-    # get newlines type, open in universal mode to find it
-    with open(filename, 'r', newline=None) as hfile:
-        if not hfile.readline():
-            return  # empty, no point
-        sep = hfile.newlines  # After reading a line, python gives us this
-    assert isinstance(sep, str), 'multiple newline types found, aborting'
-
-    # find a suitable seek position in binary mode
-    with open(filename, 'rb') as hfile:
-        hfile.seek(0, os.SEEK_END)
-        linecount = 0
-        pos = 0
-
-        while linecount <= n + 1:
-            # read at least n lines + 1 more; we need to skip a partial line later on
-            try:
-                hfile.seek(-bsize, os.SEEK_CUR)           # go backwards
-                linecount += hfile.read(bsize).count(sep.encode())  # count newlines
-                hfile.seek(-bsize, os.SEEK_CUR)           # go back again
-            except IOError as e:
-                if e.errno == errno.EINVAL:
-                    # Attempted to seek past the start, can't go further
-                    bsize = hfile.tell()
-                    hfile.seek(0, os.SEEK_SET)
-                    pos = 0
-                    linecount += hfile.read(bsize).count(sep.encode())
-                    break
-                raise  # Some other I/O exception, re-raise
-            pos = hfile.tell()
-
-    # Re-open in text mode
-    with open(filename, 'r') as hfile:
-        hfile.seek(pos, os.SEEK_SET)  # our file position from above
-        for line in hfile:
-            # We've located n lines *or more*, so skip if needed
-            if linecount > n:
-                linecount -= 1
-                continue
-            # The rest we yield
-            yield line.rstrip()
 
 
 def to_event_pages(get_event_cursor, page_size):

--- a/databroker/tests/test_v2/test_core.py
+++ b/databroker/tests/test_v2/test_core.py
@@ -83,12 +83,3 @@ def test_interlace_event_page_chunks():
     expected_page_count = (50 // 3 + 1) * 3
     assert j + 1 == expected_page_count
     assert 10*5*3 == total_events
-
-
-def test_tail():
-    with tempfile.TemporaryDirectory() as tempdir:
-        with open(os.path.join(tempdir, 'lastlines_test.txt'), 'w') as f:
-            for i in range(1000):
-                f.write(f'{i}\n')
-            filename = f.name
-        assert list(core.tail(filename, n=2)) == ['998', '999']

--- a/databroker/tests/test_v2/test_core.py
+++ b/databroker/tests/test_v2/test_core.py
@@ -3,7 +3,7 @@ import os
 import tempfile
 import xarray
 from ... import core
-from ...core import documents_to_xarray
+from ...core import _documents_to_xarray
 
 
 def no_event_pages(descriptor_uid):
@@ -28,7 +28,7 @@ def test_no_descriptors():
     run_bundle = event_model.compose_run()
     start_doc = run_bundle.start_doc
     stop_doc = run_bundle.compose_stop()
-    documents_to_xarray(
+    _documents_to_xarray(
         start_doc=start_doc,
         stop_doc=stop_doc,
         descriptor_docs=[],
@@ -47,7 +47,7 @@ def test_no_events():
         name='primary')
     descriptor_doc = desc_bundle.descriptor_doc
     stop_doc = run_bundle.compose_stop()
-    documents_to_xarray(
+    _documents_to_xarray(
         start_doc=start_doc,
         stop_doc=stop_doc,
         descriptor_docs=[descriptor_doc],
@@ -60,9 +60,9 @@ def test_no_events():
 
 def test_xarray_helpers():
     event_pages = list(event_page_gen(10, 5))
-    dataarray_pages = [core.event_page_to_dataarray_page(page) for page in event_pages]
-    dataarray_page = core.concat_dataarray_pages(dataarray_pages)
-    dataset_page = core.dataarray_page_to_dataset_page(dataarray_page)
+    dataarray_pages = [core._event_page_to_dataarray_page(page) for page in event_pages]
+    dataarray_page = core._concat_dataarray_pages(dataarray_pages)
+    dataset_page = core._dataarray_page_to_dataset_page(dataarray_page)
     assert isinstance(dataset_page['data'], xarray.Dataset)
     assert isinstance(dataset_page['timestamps'], xarray.Dataset)
     assert isinstance(dataset_page['filled'], xarray.Dataset)
@@ -70,7 +70,7 @@ def test_xarray_helpers():
 
 def test_interlace_event_page_chunks():
     page_gens = [event_page_gen(10, 5) for i in range(3)]
-    interlaced = core.interlace_event_page_chunks(*page_gens, chunk_size=3)
+    interlaced = core._interlace_event_page_chunks(*page_gens, chunk_size=3)
 
     t0 = None
     total_events = 0

--- a/databroker/tests/test_v2/test_jsonl.py
+++ b/databroker/tests/test_v2/test_jsonl.py
@@ -9,6 +9,8 @@ import time
 import types
 
 from .generic import *  # noqa
+from ..._drivers.jsonl import tail
+
 
 TMP_DIRS = {param: tempfile.mkdtemp() for param in ['local', 'remote']}
 TEST_CATALOG_PATH = TMP_DIRS['remote']  # used by intake_server fixture
@@ -78,3 +80,13 @@ sources:
                                  uid=uid,
                                  docs=docs,
                                  remote=remote)
+
+
+
+def test_tail():
+    with tempfile.TemporaryDirectory() as tempdir:
+        with open(os.path.join(tempdir, 'lastlines_test.txt'), 'w') as f:
+            for i in range(1000):
+                f.write(f'{i}\n')
+            filename = f.name
+        assert list(tail(filename, n=2)) == ['998', '999']

--- a/doc/source/v2/developer/reference.rst
+++ b/doc/source/v2/developer/reference.rst
@@ -5,6 +5,9 @@ API Reference
 Core
 ====
 
+.. autoclass:: databroker.core.Document
+   :members:
+
 .. autoclass:: databroker.core.BlueskyRun
    :members:
 
@@ -14,9 +17,11 @@ Core
 .. autoclass:: databroker.core.BlueskyEventStream
    :members:
 
-.. autofunction:: databroker.core.documents_to_xarray
+.. autofunction:: databroker.core.discover_handlers
 
 .. autofunction:: databroker.core.parse_handler_registry
+
+.. autofunction:: databroker.core.parse_transforms
 
 Utils
 =====


### PR DESCRIPTION
There are many utility methods in `core` that were written in prep for a
refactor of `databroker_to_xarray`, some of which are not actually used yet,
and maybe all of which could be moved to `event-model` because they are
generically useful for manipulating Documents. In prepartion for possibly
moving and/or re-tooling them, I have made them private except for those
that are imported to drivers.

I also moved `tail`, which a text-parsing utility only used by the JSONL driver,
into the JSONL driver.