### PR TITLE
Flake8 compliance

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,33 @@
+[flake8]
+exclude =
+    .git,
+    __pycache__,
+    build,
+    databroker/assets,
+    databroker/broker.py,
+    databroker/_core.py,
+    databroker/databroker.py,
+    databroker/eventsource,
+    databroker/glue.py,
+    databroker/headersource,
+    databroker/service,
+    databroker/tests/test_broker.py
+    databroker/tests/test_config.py
+    databroker/tests/test_discovery.py
+    databroker/tests/test_document.py
+    databroker/tests/test_glue.py
+    databroker/tests/test_humantime_munging.py
+    databroker/tests/test_lazymap.py
+    databroker/tests/test_mds.py
+    databroker/tests/test_pivot.py
+    databroker/tests/test_urls.py
+    databroker/tests/test_v2
+    databroker/tests/utils.py
+    databroker/pivot.py,
+    databroker/v0.py,
+    databroker/_version.py,
+    dist,
+    doc/source,
+    migration,
+    versioneer.py,
+max-line-length = 115

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ matrix:
   - python: 3.7  # Separate build to run flake8 check
     env:
       - INTAKE_MASTER=false
-      - FLAKE_8=true
+      - FLAKE8=true
   - python: 3.6
     env:
       - INTAKE_MASTER=false
@@ -54,7 +54,7 @@ env:
     - secure: "spb6HwGVvMPsQw9cEwJscmAlG7seL0svW8ouYlDr4OESJJJqC8bynEpAl7Zm/NuKiZ701IR9gEBFuwCRoEXNJ6AkqgBE0DOMj4Oezg4eUnaZz0aXJ+C6mz31vbcNmU6MrjSElw80cIXBpia3j//VMluMzJMsGx/ELPATu2nwyx1+KXljGpFe1/7HYcq/wFHi+sC02sZRVYJGqrb5Zms35hlk4xasWKlsgLh53kW+ss+4hY67vllL2iRkYiP+8z4e3dTOuDqJWx5lLT16wt0K+wJyP/QTyIP81tmMNoWRbdrfOrzyyVXZDbrlzpZDBRtvlMFMHOeEZOrFPIYuclEjT39Tge+T/OxR6SC8kvzqVItxyxLEKWpQu8DHRVEDAuirteuv4IKEnS80nbWn4v/sBOU+sC0/23dW9zZkMrNmRoSFcjudmy2PGIY8jxzOhGJJ+Rbi0xIaKwdLbDZoPHM3m9m2uWYfGNMBHDgnh/HDIq71zzYWaW4gChYgU0UeDM1RYnr1XRa44znlZ0YLnmEyxn/5LzH/hRDxqc5XH5OAiKLnTddZFYsvdRT1JMNSA5PRSm7E8BCvCOEwovjnvRUc0dktyd8+OC5+Eyf1neJ6M7F2sGxCi3yMKw3VmfCxINu6XO3GsPE7cKACEq0lriCxjNzFWbedOX9dTL1Uqdc3pQA="
 
 before_install:
-  - if [ ! -z "$FLAKE_8" ]; then
+  - if [ ! -z "$FLAKE8" ]; then
         pip install flake8;
         flake8 .;
         let res=$?;

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,20 +10,16 @@ matrix:
   - python: 3.6
     env:
       - INTAKE_MASTER=false
-      - FLAKE8=
   - python: 3.7
     env:
       - INTAKE_MASTER=false
-      - FLAKE8=
   - python: 3.7
     env:
       - INTAKE_MASTER=true
       - PUBLISH_DOCS=true
-      - FLAKE8=
   - python: nightly
     env:
       - INTAKE_MASTER=false
-      - FLAKE8=
     addons:
       apt:
         packages:

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,14 +3,27 @@ language: python
 matrix:
   fast_finish: true
   include:
+  - python: 3.7  # Separate build to run flake8 check
+    env:
+      - INTAKE_MASTER=false
+      - FLAKE_8=true
   - python: 3.6
-    env: INTAKE_MASTER=false
+    env:
+      - INTAKE_MASTER=false
+      - FLAKE8=
   - python: 3.7
-    env: INTAKE_MASTER=false
+    env:
+      - INTAKE_MASTER=false
+      - FLAKE8=
   - python: 3.7
-    env: INTAKE_MASTER=true PUBLISH_DOCS=true
+    env:
+      - INTAKE_MASTER=true
+      - PUBLISH_DOCS=true
+      - FLAKE8=
   - python: nightly
-    env: INTAKE_MASTER=false
+    env:
+      - INTAKE_MASTER=false
+      - FLAKE8=
     addons:
       apt:
         packages:
@@ -41,6 +54,13 @@ env:
     - secure: "spb6HwGVvMPsQw9cEwJscmAlG7seL0svW8ouYlDr4OESJJJqC8bynEpAl7Zm/NuKiZ701IR9gEBFuwCRoEXNJ6AkqgBE0DOMj4Oezg4eUnaZz0aXJ+C6mz31vbcNmU6MrjSElw80cIXBpia3j//VMluMzJMsGx/ELPATu2nwyx1+KXljGpFe1/7HYcq/wFHi+sC02sZRVYJGqrb5Zms35hlk4xasWKlsgLh53kW+ss+4hY67vllL2iRkYiP+8z4e3dTOuDqJWx5lLT16wt0K+wJyP/QTyIP81tmMNoWRbdrfOrzyyVXZDbrlzpZDBRtvlMFMHOeEZOrFPIYuclEjT39Tge+T/OxR6SC8kvzqVItxyxLEKWpQu8DHRVEDAuirteuv4IKEnS80nbWn4v/sBOU+sC0/23dW9zZkMrNmRoSFcjudmy2PGIY8jxzOhGJJ+Rbi0xIaKwdLbDZoPHM3m9m2uWYfGNMBHDgnh/HDIq71zzYWaW4gChYgU0UeDM1RYnr1XRa44znlZ0YLnmEyxn/5LzH/hRDxqc5XH5OAiKLnTddZFYsvdRT1JMNSA5PRSm7E8BCvCOEwovjnvRUc0dktyd8+OC5+Eyf1neJ6M7F2sGxCi3yMKw3VmfCxINu6XO3GsPE7cKACEq0lriCxjNzFWbedOX9dTL1Uqdc3pQA="
 
 before_install:
+  - if [ ! -z "$FLAKE_8" ]; then
+        pip install flake8;
+        flake8 .;
+        let res=$?;
+        echo "The project code was verified by 'flake8'. Exit code ($res).";
+        exit $res;
+    fi
   - export TZ=US/Eastern
 
 install:

--- a/databroker/__init__.py
+++ b/databroker/__init__.py
@@ -1,22 +1,22 @@
 # Import intake to run driver discovery first and avoid circular import issues.
-import intake
-
-import warnings
 import logging
+
+import intake  # noqa: F401
+from intake.catalog.default import load_combo_catalog
+
+from .v1 import Broker, Header, ALL, temp, temp_config  # noqa: F401
+from .utils import (  # noqa: 401
+    lookup_config, list_configs, describe_configs,  # noqa: F401
+    wrap_in_doct, DeprecatedDoct, wrap_in_deprecated_doct,  # noqa: F401
+    catalog_search_path)  # noqa: F401
+
+from .discovery import MergedCatalog, EntrypointsCatalog, V0Catalog
 
 
 logger = logging.getLogger(__name__)
 
 
-from .v1 import Broker, Header, ALL, temp, temp_config
-from .utils import (lookup_config, list_configs, describe_configs,
-                    wrap_in_doct, DeprecatedDoct, wrap_in_deprecated_doct,
-                    catalog_search_path)
-
-from .discovery import MergedCatalog, EntrypointsCatalog, V0Catalog
-
 # A catalog created from discovered entrypoints, v0, and intake YAML catalogs.
-from intake.catalog.default import load_combo_catalog
 yaml_catalogs = load_combo_catalog()
 catalog = MergedCatalog([
     EntrypointsCatalog(),
@@ -24,19 +24,20 @@ catalog = MergedCatalog([
     load_combo_catalog()])
 
 # set version string using versioneer
-from ._version import get_versions
+from ._version import get_versions  # noqa: F402
 __version__ = get_versions()['version']
 del get_versions
 
 
-### Legacy imports ###
+# Legacy imports
 
 try:
     from .databroker import DataBroker
 except ImportError:
     pass
 else:
-    from .databroker import (DataBroker, DataBroker as db,
+    from .databroker import (DataBroker,  # noqa: 811
+                             DataBroker as db,
                              get_events, get_table, stream, get_fields,
                              restream, process)
-    from .pims_readers import get_images
+    from .pims_readers import get_images  # noqa: F401

--- a/databroker/_drivers/mongo_embedded.py
+++ b/databroker/_drivers/mongo_embedded.py
@@ -4,14 +4,10 @@ from sys import maxsize
 from functools import partial
 import logging
 import cachetools
-import intake
-import intake.catalog
-import intake.catalog.local
-import intake.source.base
 import pymongo
 import pymongo.errors
 
-from ..core import parse_handler_registry, discover_handlers, Entry
+from ..core import Entry
 from ..v2 import Broker
 
 

--- a/databroker/_drivers/mongo_normalized.py
+++ b/databroker/_drivers/mongo_normalized.py
@@ -1,19 +1,12 @@
 import collections.abc
-import functools
 import event_model
 from functools import partial
 import logging
 import cachetools
-import intake
-import intake.catalog
-import intake.catalog.local
-import intake.source.base
 import pymongo
 import pymongo.errors
 
-from ..core import (
-    parse_handler_registry, discover_handlers, to_event_pages, to_datum_pages,
-    Entry)
+from ..core import to_event_pages, to_datum_pages, Entry
 from ..v2 import Broker
 
 
@@ -47,7 +40,7 @@ class _Entries(collections.abc.Mapping):
             get_event_pages=to_event_pages(self.catalog._get_event_cursor, 2500),
             get_event_count=self.catalog._get_event_count,
             get_resource=self.catalog._get_resource,
-            get_resources=partial(self.catalog._get_resources,uid),
+            get_resources=partial(self.catalog._get_resources, uid),
             lookup_resource_for_datum=self.catalog._lookup_resource_for_datum,
             # 2500 was selected as the page_size because it worked well durring
             # benchmarks.
@@ -286,8 +279,8 @@ class BlueskyMongoCatalog(Broker):
             {'descriptor': descriptor_uid})
 
     def _get_resources(self, run_start_uid):
-        return list(self._resource_collection.find({'run_start': run_start_uid},
-                                              {'_id': False}))
+        return list(self._resource_collection.find(
+            {'run_start': run_start_uid}, {'_id': False}))
 
     def _get_resource(self, uid):
         doc = self._resource_collection.find_one(

--- a/databroker/core.py
+++ b/databroker/core.py
@@ -1761,7 +1761,7 @@ def parse_transforms(transforms):
     transformable = {'start', 'stop', 'resource', 'descriptor'}
 
     if transforms is None:
-        result = {key: lambda doc: doc for key in transformable}
+        result = {key: _no_op for key in transformable}
         return result
     elif isinstance(transforms, collections.abc.Mapping):
         if len(transforms.keys() - transformable) > 0:
@@ -1769,16 +1769,13 @@ def parse_transforms(transforms):
                                       f"are not supported.")
         result = {}
 
-        def no_op(doc):
-            return doc
-
         for name in transformable:
             transform = transforms.get(name)
             if isinstance(transform, str):
                 module_name, _, class_name = transform.rpartition('.')
                 function = getattr(importlib.import_module(module_name), class_name)
             elif transform is None:
-                function = no_op
+                function = _no_op
             else:
                 function = transform
             result[name] = function
@@ -1959,6 +1956,10 @@ def extract_dtype(descriptor, key):
         return float  # guess!
     else:
         return reported
+
+
+def _no_op(doc):
+    return doc
 
 
 # This comes from the old databroker.core from before intake-bluesky was merged

--- a/databroker/discovery.py
+++ b/databroker/discovery.py
@@ -5,6 +5,7 @@ from intake.catalog import Catalog
 from intake.catalog.entry import CatalogEntry
 import warnings
 
+
 class EntrypointEntry(CatalogEntry):
     """
     A catalog entry for an entrypoint.

--- a/databroker/in_memory.py
+++ b/databroker/in_memory.py
@@ -1,11 +1,6 @@
-import copy
 import event_model
-import intake
-import intake.catalog
-import intake.catalog.local
-import intake.source.base
 
-from .core import parse_handler_registry, discover_handlers, Entry
+from .core import Entry
 from .v2 import Broker
 from mongoquery import Query
 

--- a/databroker/queries.py
+++ b/databroker/queries.py
@@ -12,7 +12,7 @@ from .utils import normalize_human_friendly_time
 class Query(collections.abc.Mapping):
     """
     This represents a MongoDB query.
-    
+
     MongoDB queries are typically encoded as simple dicts. This object supports
     the dict interface in a read-only fashion. Subclassses add a nice __repr__
     and mutable attributes from which the contents of the dict are derived.
@@ -30,7 +30,7 @@ class Query(collections.abc.Mapping):
 
     def __getitem__(self, key):
         return self.query[key]
-    
+
     def __len__(self):
         return len(self.query)
 

--- a/databroker/tests/conftest.py
+++ b/databroker/tests/conftest.py
@@ -8,7 +8,7 @@ from databroker.tests.utils import (build_sqlite_backed_broker,
                                     build_hdf5_backed_broker,
                                     build_intake_jsonl_backed_broker,
                                     build_intake_mongo_backed_broker,
-                                    build_intake_mongo_embedded_backed_broker,
+                                    # build_intake_mongo_embedded_backed_broker,
                                     build_client_backend_broker,
                                     start_md_server,
                                     stop_md_server)
@@ -23,7 +23,7 @@ from ..headersource import sqlite as sqlmds
 
 if sys.version_info >= (3, 5):
     # this is a pytest.fixture
-    from bluesky.tests.conftest import RE
+    from bluesky.tests.conftest import RE  # noqa: F401
 
     @pytest.fixture(scope='function')
     def hw(request):

--- a/examples/generate_mongo_data.py
+++ b/examples/generate_mongo_data.py
@@ -1,11 +1,12 @@
 # generate_data.py
 import logging
-import tempfile
 from suitcase.mongo_normalized import Serializer
 from bluesky import RunEngine
 from bluesky.plans import count
 from ophyd.sim import det
 import uuid
+
+from databroker._drivers.mongo_normalized import BlueskyMongoCatalog
 
 
 RE = RunEngine()
@@ -22,5 +23,4 @@ handler = logging.StreamHandler()
 handler.setLevel('DEBUG')
 logger.addHandler(handler)
 
-from databroker._drivers.mongo_normalized import BlueskyMongoCatalog
-catalog = BlueskyMongoCatalog(f'{directory}/*.msgpack')
+catalog = BlueskyMongoCatalog(mds, fs)

--- a/examples/generate_mongo_embedded_data.py
+++ b/examples/generate_mongo_embedded_data.py
@@ -1,13 +1,13 @@
 # generate_data.py
 import logging
-import tempfile
 from suitcase.mongo_embedded import Serializer
 from bluesky import RunEngine
 from bluesky.plans import count
 from ophyd.sim import det
 import pymongo
 import uuid
-import time
+
+from databroker._drivers.mongo_embedded import BlueskyMongoCatalog
 
 
 RE = RunEngine()
@@ -27,5 +27,4 @@ handler = logging.StreamHandler()
 handler.setLevel('DEBUG')
 logger.addHandler(handler)
 
-from databroker._drivers.mongo_embedded import BlueskyMongoCatalog
-catalog = BlueskyMongoCatalog(f'{directory}/*.msgpack')
+catalog = BlueskyMongoCatalog(uri)

--- a/examples/generate_msgpack_data.py
+++ b/examples/generate_msgpack_data.py
@@ -1,4 +1,3 @@
-# generate_data.py
 import logging
 import tempfile
 from suitcase.msgpack import Serializer
@@ -6,6 +5,7 @@ from bluesky import RunEngine
 from bluesky.plans import count
 from ophyd.sim import det
 
+from databroker._drivers.msgpack import BlueskyMsgpackCatalog
 
 RE = RunEngine()
 
@@ -21,5 +21,4 @@ handler = logging.StreamHandler()
 handler.setLevel('DEBUG')
 logger.addHandler(handler)
 
-from databroker._drivers.msgpack import BlueskyMsgpackCatalog
 catalog = BlueskyMsgpackCatalog(f'{directory}/*.msgpack')


### PR DESCRIPTION
Inspired by https://github.com/bluesky/ophyd/pull/823 and https://github.com/bluesky/bluesky/pull/1326, this runs `flake8` in the databroker CI and brings (some of) the codebase into compliance.

The flake8 configuration file excludes modules, scripts, and tests related to v0 because the v0 code is expected to be deprecated and removed once v1 (which provides a v0-compatible API shimmed on top of v2) in proven reliable.

Changes include whitespace, removing unused imports, reordering imports, removing some unused local variables, adding some missing f-strings, and fixing some misspelled variables on a new codepath that is apparently untested.