### PR TITLE
Fix python2 codepath.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ This may be due to an out-of-date pip. Make sure you have pip >= 9.0.1.
 Upgrade pip like so:
 
 pip install --upgrade pip
-""".format(*sys.version_info[:2], *min_version)
+""".format(*(sys.version_info[:2] + min_version))
     sys.exit(error)
 
 here = path.abspath(path.dirname(__file__))


### PR DESCRIPTION
Code was not actually valid Python 2 syntax, so the nice error never
showed. Testd with `python2 setup.py sdist`.