### PR TITLE
Try __getitem__ again with a forced reload.

### DIFF
--- a/databroker/_drivers/jsonl.py
+++ b/databroker/_drivers/jsonl.py
@@ -6,7 +6,7 @@ import pathlib
 import event_model
 
 from ..in_memory import BlueskyInMemoryCatalog
-
+from ..core import retry
 
 def gen(filename):
     """
@@ -142,6 +142,7 @@ class BlueskyJSONLCatalog(BlueskyInMemoryCatalog):
                 stop_doc = get_stop(filename)
                 self.upsert(start_doc, stop_doc, gen, (filename,), {})
 
+    @retry
     def search(self, query):
         """
         Return a new Catalog with a subset of the entries in this Catalog.

--- a/databroker/_drivers/jsonl.py
+++ b/databroker/_drivers/jsonl.py
@@ -8,6 +8,7 @@ import event_model
 from ..in_memory import BlueskyInMemoryCatalog
 from ..core import retry
 
+
 def gen(filename):
     """
     A JSONL file generator.

--- a/databroker/core.py
+++ b/databroker/core.py
@@ -340,11 +340,12 @@ def retry(function):
     """
 
     @functools.wraps(function)
-    def new_function(*args, **kwargs):
+    def new_function(self, *args, **kwargs):
         try:
-            function(*args, **kwargs)
+            return function(self, *args, **kwargs)
         except Exception:
-            function(*args, **kwargs)
+            self.force_reload()
+            return function(self, *args, **kwargs)
 
     return new_function
 

--- a/databroker/core.py
+++ b/databroker/core.py
@@ -326,6 +326,29 @@ def to_datum_pages(get_datum_cursor, page_size):
     return get_datum_pages
 
 
+def retry(function):
+    """
+    Decorator that retries a function once.
+
+    Parameters
+    ----------
+    function: function
+
+    Returns
+    -------
+    new_function: function
+    """
+
+    @functools.wraps(function)
+    def new_function(*args, **kwargs):
+        try:
+            function(*args, **kwargs)
+        except Exception:
+            function(*args, **kwargs)
+
+    return new_function
+
+
 def _flatten_event_page_gen(gen):
     """
     Converts an event_page generator to an event generator.

--- a/databroker/core.py
+++ b/databroker/core.py
@@ -328,7 +328,7 @@ def to_datum_pages(get_datum_cursor, page_size):
 
 def retry(function):
     """
-    Decorator that retries a function once.
+    Decorator that retries a Catalog function once.
 
     Parameters
     ----------

--- a/databroker/in_memory.py
+++ b/databroker/in_memory.py
@@ -151,7 +151,7 @@ class BlueskyInMemoryCatalog(Broker):
         else:
             # Sort in reverse chronological order (most recent first).
             time_sorted = sorted(self._uid_to_run_start_doc.values(),
-                                key=lambda doc: -doc['time'])
+                                 key=lambda doc: -doc['time'])
             if N < 0:
                 # Force a reload because a stale cache is a big problem for
                 # recency-based lookups.

--- a/databroker/in_memory.py
+++ b/databroker/in_memory.py
@@ -1,6 +1,6 @@
 import event_model
 
-from .core import Entry
+from .core import Entry, retry
 from .v2 import Broker
 from mongoquery import Query
 
@@ -125,65 +125,59 @@ class BlueskyInMemoryCatalog(Broker):
                        args['gen_kwargs'])
         return cat
 
-    def __getitem__(self, name, attempt=0):
+    @retry
+    def __getitem__(self, name):
+        # If this came from a client, we might be getting '-1'.
         try:
-            # If this came from a client, we might be getting '-1'.
-            try:
-                N = int(name)
-            except (ValueError, TypeError):
-                if name in self._uid_to_run_start_doc:
-                    uid = name
-                else:
-                    # Try looking up by *partial* uid.
-                    matches = []
-                    for uid, run_start_doc in list(self._uid_to_run_start_doc.items()):
-                        if uid.startswith(name):
-                            matches.append(uid)
-                    if not matches:
-                        raise KeyError(name)
-                    elif len(matches) > 1:
-                        match_list = '\n'.join(matches)
-                        raise ValueError(
-                            f"Multiple matches to partial uid {name!r}:\n"
-                            f"{match_list}")
-                    else:
-                        uid, = matches
+            N = int(name)
+        except (ValueError, TypeError):
+            if name in self._uid_to_run_start_doc:
+                uid = name
             else:
-                # Sort in reverse chronological order (most recent first).
-                time_sorted = sorted(self._uid_to_run_start_doc.values(),
-                                    key=lambda doc: -doc['time'])
-                if N < 0:
-                    # Force a reload because a stale cache is a big problem for
-                    # recency-based lookups.
-                    self.force_reload()
-                    # Interpret negative N as "the Nth from last entry".
-                    if -N > len(time_sorted):
-                        raise IndexError(
-                            f"Catalog only contains {len(time_sorted)} "
-                            f"runs.")
-                    uid = time_sorted[-N - 1]['uid']
+                # Try looking up by *partial* uid.
+                matches = []
+                for uid, run_start_doc in list(self._uid_to_run_start_doc.items()):
+                    if uid.startswith(name):
+                        matches.append(uid)
+                if not matches:
+                    raise KeyError(name)
+                elif len(matches) > 1:
+                    match_list = '\n'.join(matches)
+                    raise ValueError(
+                        f"Multiple matches to partial uid {name!r}:\n"
+                        f"{match_list}")
                 else:
-                    # Interpret positive N as
-                    # "most recent entry with scan_id == N".
-                    for run_start_doc in time_sorted:
-                        if run_start_doc.get('scan_id') == N:
-                            uid = run_start_doc['uid']
-                            break
-                    else:
-                        raise KeyError(f"No run with scan_id={N}")
-            entry = self._entries[uid]
-            # The user has requested one specific Entry. In order to give them a
-            # more useful object, 'get' the Entry for them. Note that if they are
-            # expecting an Entry and try to call ``()`` or ``.get()``, that will
-            # still work because BlueskyRun supports those methods and will just
-            # return itself.
-            return entry.get()  # an instance of BlueskyRun
-        except Exception as err:
-            if attempt == 0:
+                    uid, = matches
+        else:
+            # Sort in reverse chronological order (most recent first).
+            time_sorted = sorted(self._uid_to_run_start_doc.values(),
+                                key=lambda doc: -doc['time'])
+            if N < 0:
+                # Force a reload because a stale cache is a big problem for
+                # recency-based lookups.
                 self.force_reload()
-                self.__getitem__(name, attempt=1)
+                # Interpret negative N as "the Nth from last entry".
+                if -N > len(time_sorted):
+                    raise IndexError(
+                        f"Catalog only contains {len(time_sorted)} "
+                        f"runs.")
+                uid = time_sorted[-N - 1]['uid']
             else:
-                raise err
+                # Interpret positive N as
+                # "most recent entry with scan_id == N".
+                for run_start_doc in time_sorted:
+                    if run_start_doc.get('scan_id') == N:
+                        uid = run_start_doc['uid']
+                        break
+                else:
+                    raise KeyError(f"No run with scan_id={N}")
+        entry = self._entries[uid]
+        # The user has requested one specific Entry. In order to give them a
+        # more useful object, 'get' the Entry for them. Note that if they are
+        # expecting an Entry and try to call ``()`` or ``.get()``, that will
+        # still work because BlueskyRun supports those methods and will just
+        # return itself.
+        return entry.get()  # an instance of BlueskyRun
 
     def __len__(self):
         return len(self._uid_to_run_start_doc)

--- a/databroker/in_memory.py
+++ b/databroker/in_memory.py
@@ -178,10 +178,12 @@ class BlueskyInMemoryCatalog(Broker):
             # still work because BlueskyRun supports those methods and will just
             # return itself.
             return entry.get()  # an instance of BlueskyRun
-        except Exception:
+        except Exception as err:
             if attempt == 0:
                 self.force_reload()
-                self.__getitem__(key, attempt=1)
+                self.__getitem__(name, attempt=1)
+            else:
+                raise err
 
     def __len__(self):
         return len(self._uid_to_run_start_doc)

--- a/databroker/tests/test_v2/generic.py
+++ b/databroker/tests/test_v2/generic.py
@@ -323,7 +323,6 @@ def test_catalog_update(bundle, RE, hw):
     """
     serializer = bundle.serializer_partial()
     new_uid = RE(count([hw.img]), serializer)[0]
-    time.sleep(10)
     name, start_doc = next(bundle.cat['xyz']()[-1].canonical(fill='no'))
 
     assert start_doc['uid'] == new_uid

--- a/databroker/tests/test_v2/generic.py
+++ b/databroker/tests/test_v2/generic.py
@@ -314,5 +314,10 @@ def test_items(bundle):
 
 
 def test_catalog_update(bundle):
-    latest = repr(bundle.cat['xyz']()[-1])
     serializer = bundle.serializer_partial()
+    for name, doc in bundle.docs:
+        if name == 'start':
+            doc['uid'] = 'latest'
+        serializer(name, doc)
+    start_doc = next(bundle.cat['xyz']()[-1].canonical(fill='no'))
+    assert start_doc['uid'] = 'latest'

--- a/databroker/tests/test_v2/generic.py
+++ b/databroker/tests/test_v2/generic.py
@@ -315,4 +315,4 @@ def test_items(bundle):
 
 def test_catalog_update(bundle):
     latest = repr(bundle.cat['xyz']()[-1])
-    print(type(serializer))
+    serializer = bundle.serializer_partial()

--- a/databroker/tests/test_v2/generic.py
+++ b/databroker/tests/test_v2/generic.py
@@ -314,6 +314,10 @@ def test_items(bundle):
 
 
 def test_catalog_update(bundle):
+    """
+    Check that a new run is accessable with -1 immediatly after it is
+    finished being serialized.
+    """
     serializer = bundle.serializer_partial()
     for name, doc in bundle.docs:
         if name == 'start':

--- a/databroker/tests/test_v2/generic.py
+++ b/databroker/tests/test_v2/generic.py
@@ -322,15 +322,7 @@ def test_catalog_update(bundle, RE, hw):
     finished being serialized.
     """
     serializer = bundle.serializer_partial()
-    docs = []
-
-    def callback(name, doc):
-        docs.append((name, doc))
-
     new_uid = RE(count([hw.img]), serializer)[0]
-
-    for name, doc in docs:
-        serializer(name, doc)
     time.sleep(10)
     name, start_doc = next(bundle.cat['xyz']()[-1].canonical(fill='no'))
 

--- a/databroker/tests/test_v2/generic.py
+++ b/databroker/tests/test_v2/generic.py
@@ -6,6 +6,7 @@ from intake.catalog.utils import RemoteCatalogError
 import numpy
 import ophyd.sim
 import pytest
+import time
 import uuid
 
 
@@ -321,7 +322,17 @@ def test_catalog_update(bundle, RE, hw):
     finished being serialized.
     """
     serializer = bundle.serializer_partial()
+    docs = []
+
+    def callback(name, doc):
+        docs.append((name, doc))
+
     new_uid = RE(count([hw.img]), serializer)[0]
+
+    for name, doc in docs:
+        serializer(name, doc)
+    time.sleep(10)
     name, start_doc = next(bundle.cat['xyz']()[-1].canonical(fill='no'))
+
     assert start_doc['uid'] == new_uid
 

--- a/databroker/tests/test_v2/generic.py
+++ b/databroker/tests/test_v2/generic.py
@@ -1,10 +1,12 @@
 import collections
 import event_model
 import itertools
+from bluesky.plans import count
 from intake.catalog.utils import RemoteCatalogError
 import numpy
 import ophyd.sim
 import pytest
+import uuid
 
 
 def normalize(gen):
@@ -313,15 +315,13 @@ def test_items(bundle):
         assert hasattr(run, 'canonical')
 
 
-def test_catalog_update(bundle):
+def test_catalog_update(bundle, RE, hw):
     """
     Check that a new run is accessable with -1 immediatly after it is
     finished being serialized.
     """
     serializer = bundle.serializer_partial()
-    for name, doc in bundle.docs:
-        if name == 'start':
-            doc['uid'] = 'latest'
-        serializer(name, doc)
-    start_doc = next(bundle.cat['xyz']()[-1].canonical(fill='no'))
-    assert start_doc['uid'] = 'latest'
+    new_uid = RE(count([hw.img]), serializer)[0]
+    name, start_doc = next(bundle.cat['xyz']()[-1].canonical(fill='no'))
+    assert start_doc['uid'] == new_uid
+

--- a/databroker/tests/test_v2/generic.py
+++ b/databroker/tests/test_v2/generic.py
@@ -311,3 +311,8 @@ def test_items(bundle):
         pytest.xfail("Regression in intake 0.6.0 awaiting patch")
     for uid, run in bundle.cat['xyz']().items():
         assert hasattr(run, 'canonical')
+
+
+def test_catalog_update(bundle):
+    latest = repr(bundle.cat['xyz']()[-1])
+    print(type(serializer))

--- a/databroker/tests/test_v2/test_jsonl.py
+++ b/databroker/tests/test_v2/test_jsonl.py
@@ -1,4 +1,5 @@
 import intake
+from functools import partial
 from suitcase.jsonl import Serializer
 import os
 from pathlib import Path
@@ -30,7 +31,8 @@ def teardown_module(module):
 def bundle(request, intake_server, example_data):  # noqa
     tmp_dir = TMP_DIRS[request.param]
     tmp_data_dir = Path(tmp_dir) / 'data'
-    serializer = Serializer(tmp_data_dir)
+    serializer_partial = partial(Serializer, tmp_data_dir)
+    serializer = serializer_partial()
     uid, docs = example_data
     for name, doc in docs:
         serializer(name, doc)
@@ -79,7 +81,8 @@ sources:
     return types.SimpleNamespace(cat=cat,
                                  uid=uid,
                                  docs=docs,
-                                 remote=remote)
+                                 remote=remote,
+                                 serializer_partial=serializer_partial)
 
 
 

--- a/databroker/tests/test_v2/test_jsonl.py
+++ b/databroker/tests/test_v2/test_jsonl.py
@@ -47,7 +47,7 @@ sources:
     driver: "bluesky-jsonl-catalog"
     container: catalog
     args:
-      paths: {[str(path) for path in serializer.artifacts['all']]}
+      paths: {tmp_data_dir / "*.jsonl"}
       handler_registry:
         NPY_SEQ: ophyd.sim.NumpySeqHandler
     metadata:
@@ -57,7 +57,7 @@ sources:
     driver: "bluesky-jsonl-catalog"
     container: catalog
     args:
-      paths: {[str(path) for path in serializer.artifacts['all']]}
+      paths: [{tmp_data_dir / "*.jsonl"}]
       handler_registry:
         NPY_SEQ: ophyd.sim.NumpySeqHandler
       transforms:

--- a/databroker/tests/test_v2/test_mongo_embedded.py
+++ b/databroker/tests/test_v2/test_mongo_embedded.py
@@ -1,4 +1,5 @@
 import intake
+from functools import partial
 from suitcase.mongo_embedded import Serializer
 import os
 import pytest
@@ -26,7 +27,8 @@ def teardown_module(module):
 def bundle(request, intake_server, example_data, db_factory):  # noqa
     fullname = os.path.join(TMP_DIR, YAML_FILENAME)
     permanent_db = db_factory()
-    serializer = Serializer(permanent_db)
+    serializer_partial = partial(Serializer, permanent_db)
+    serializer = serializer_partial()
     uid, docs = example_data
     for name, doc in docs:
         serializer(name, doc)
@@ -76,4 +78,5 @@ sources:
     return types.SimpleNamespace(cat=cat,
                                  uid=uid,
                                  docs=docs,
-                                 remote=remote)
+                                 remote=remote,
+                                 serializer_partial=serializer_partial)

--- a/databroker/tests/test_v2/test_mongo_normalized.py
+++ b/databroker/tests/test_v2/test_mongo_normalized.py
@@ -1,4 +1,5 @@
 import intake
+from functools import partial
 from intake.catalog.utils import RemoteCatalogError
 from suitcase.mongo_normalized import Serializer
 import os
@@ -28,7 +29,9 @@ def bundle(request, intake_server, example_data, db_factory):  # noqa
     fullname = os.path.join(TMP_DIR, YAML_FILENAME)
     mds_db = db_factory()
     assets_db = db_factory()
-    serializer = Serializer(mds_db, assets_db)
+    serializer_partial = partial(Serializer, mds_db, assets_db)
+    serializer = serializer_partial()
+
     uid, docs = example_data
     for name, doc in docs:
         serializer(name, doc)
@@ -80,7 +83,8 @@ sources:
     return types.SimpleNamespace(cat=cat,
                                  uid=uid,
                                  docs=docs,
-                                 remote=remote)
+                                 remote=remote,
+                                 serializer_partial=serializer_partial)
 
 
 # Driver-specific tests

--- a/databroker/tests/test_v2/test_msgpack.py
+++ b/databroker/tests/test_v2/test_msgpack.py
@@ -44,7 +44,7 @@ sources:
     driver: "bluesky-msgpack-catalog"
     container: catalog
     args:
-      paths: {[str(path) for path in serializer.artifacts['all']]}
+      paths: {tmp_data_dir / "*.msgpack"}
       handler_registry:
         NPY_SEQ: ophyd.sim.NumpySeqHandler
     metadata:
@@ -54,7 +54,7 @@ sources:
     driver: "bluesky-msgpack-catalog"
     container: catalog
     args:
-      paths: {[str(path) for path in serializer.artifacts['all']]}
+      paths: {tmp_data_dir / "*.msgpack"}
       handler_registry:
         NPY_SEQ: ophyd.sim.NumpySeqHandler
       transforms:

--- a/databroker/tests/test_v2/test_msgpack.py
+++ b/databroker/tests/test_v2/test_msgpack.py
@@ -1,5 +1,6 @@
 import intake
 from suitcase.msgpack import Serializer
+from functools import partial
 import os
 from pathlib import Path
 import pytest
@@ -28,7 +29,8 @@ def teardown_module(module):
 def bundle(request, intake_server, example_data):  # noqa
     tmp_dir = TMP_DIRS[request.param]
     tmp_data_dir = Path(tmp_dir) / 'data'
-    serializer = Serializer(tmp_data_dir)
+    serializer_partial = partial(Serializer, tmp_data_dir)
+    serializer = serializer_partial()
     uid, docs = example_data
     for name, doc in docs:
         serializer(name, doc)
@@ -76,4 +78,5 @@ sources:
     return types.SimpleNamespace(cat=cat,
                                  uid=uid,
                                  docs=docs,
-                                 remote=remote)
+                                 remote=remote,
+                                 serializer_partial=serializer_partial)

--- a/databroker/tests/test_v2/test_msgpack.py
+++ b/databroker/tests/test_v2/test_msgpack.py
@@ -1,6 +1,6 @@
 import intake
-from suitcase.msgpack import Serializer
 from functools import partial
+from suitcase.msgpack import Serializer
 import os
 from pathlib import Path
 import pytest


### PR DESCRIPTION
* If a __getitem__ lookup fails, try again after forcing a reload.
* Proactively force a reload before recency-based indexing (e.g.
``catalog[-1]``) because a stale cache is a big problem in that case.

This is dashed off and needs careful thought before merging. ~Also, it should be applied to the mongo drivers if indeed it is to be merged.~