### PR TITLE
Add test for extracting xarrays from document streams with multiple descriptors with same/unique names. 

### DIFF
--- a/databroker/core.py
+++ b/databroker/core.py
@@ -620,9 +620,9 @@ def _documents_to_xarray(*, start_doc, stop_doc, descriptor_docs,
             keys = list(data_keys)
 
     # Collect a Dataset for each descriptor. Merge at the end.
-    dim_counter = itertools.count()
     datasets = []
     for descriptor in descriptor_docs:
+        dim_counter = itertools.count()
         events = list(_flatten_event_page_gen(get_event_pages(descriptor['uid'])))
         if not events:
             continue

--- a/databroker/tests/test_v2/test_multi_descriptor.py
+++ b/databroker/tests/test_v2/test_multi_descriptor.py
@@ -11,32 +11,40 @@ data_shape = (1000, 1000)
 @fixture
 def multi_descriptor_doc_stream(request):
     streams = request.param
+
     def doc_gen(stream_names):
 
         # Compose run start
         run_bundle = event_model.compose_run()  # type: event_model.ComposeRunBundle
         start_doc = run_bundle.start_doc
 
-        yield 'start', start_doc
+        yield "start", start_doc
 
         for stream_name in stream_names:
 
             data = np.random.random(data_shape)
 
             # Compose descriptor
-            source = 'NCEM'
-            frame_data_keys = {'raw': {'source': source,
-                                       'dtype': 'number',
-                                       'shape': data.shape}}
-            frame_stream_bundle = run_bundle.compose_descriptor(data_keys=frame_data_keys,
-                                                                name=stream_name,
-                                                                )
-            yield 'descriptor', frame_stream_bundle.descriptor_doc
+            source = "NCEM"
+            frame_data_keys = {
+                "raw": {
+                    "source": source,
+                    "dtype": "array",
+                    "shape": data.shape,
+                    "dims": ("x", "y"),
+                }
+            }
+            frame_stream_bundle = run_bundle.compose_descriptor(
+                data_keys=frame_data_keys, name=stream_name,
+            )
+            yield "descriptor", frame_stream_bundle.descriptor_doc
 
-            yield 'event', frame_stream_bundle.compose_event(data={'raw': data},
-                                                             timestamps={'raw': time.time()})
+            yield "event", frame_stream_bundle.compose_event(
+                data={"raw": data}, timestamps={"raw": time.time()}
+            )
 
-        yield 'stop', run_bundle.compose_stop()
+        yield "stop", run_bundle.compose_stop()
+
     return doc_gen(streams)
 
 
@@ -51,15 +59,21 @@ def _test_ingest_to_xarray(stream):
 
     catalog.upsert(start, stop, doc_gen, [], {})
 
-    assert catalog[-1]['primary'].to_dask()['raw'].compute().shape == (1, *data_shape)
+    assert catalog[-1]["primary"].to_dask()["raw"].compute().shape == (
+        stop["num_events"]["primary"],
+        *data_shape,
+    )
 
 
-@pytest.mark.parametrize("multi_descriptor_doc_stream", (["primary", "baseline"],), indirect=True)
+@pytest.mark.parametrize(
+    "multi_descriptor_doc_stream", (["primary", "baseline"],), indirect=True
+)
 def test_multi_descriptors_unique(multi_descriptor_doc_stream):
     _test_ingest_to_xarray(multi_descriptor_doc_stream)
 
 
-@pytest.mark.parametrize("multi_descriptor_doc_stream", (["primary", "primary"],), indirect=True)
+@pytest.mark.parametrize(
+    "multi_descriptor_doc_stream", (["primary", "primary"],), indirect=True
+)
 def test_multi_descriptors_same(multi_descriptor_doc_stream):
     _test_ingest_to_xarray(multi_descriptor_doc_stream)
-

--- a/databroker/tests/test_v2/test_multi_descriptor.py
+++ b/databroker/tests/test_v2/test_multi_descriptor.py
@@ -1,0 +1,69 @@
+from pytest import fixture
+import pytest
+import event_model
+import numpy as np
+import time
+from databroker.in_memory import BlueskyInMemoryCatalog
+
+data_shape = (1000, 1000)
+
+
+@fixture
+def multi_descriptor_doc_stream(request):
+    streams = request.param
+    def doc_gen(stream_names):
+
+        print('names:', stream_names)
+
+        # Compose run start
+        run_bundle = event_model.compose_run()  # type: event_model.ComposeRunBundle
+        start_doc = run_bundle.start_doc
+
+        yield 'start', start_doc
+
+        for stream_name in stream_names:
+
+            data = np.random.random(data_shape)
+
+            # Compose descriptor
+            source = 'NCEM'
+            frame_data_keys = {'raw': {'source': source,
+                                       'dtype': 'number',
+                                       'shape': data.shape}}
+            frame_stream_bundle = run_bundle.compose_descriptor(data_keys=frame_data_keys,
+                                                                name=stream_name,
+                                                                )
+            yield 'descriptor', frame_stream_bundle.descriptor_doc
+
+            yield 'event', frame_stream_bundle.compose_event(data={'raw': data},
+                                                             timestamps={'raw': time.time()})
+
+        yield 'stop', run_bundle.compose_stop()
+    return doc_gen(streams)
+
+
+def _test_ingest_to_xarray(stream):
+    docs = list(stream)
+    catalog = BlueskyInMemoryCatalog()
+    print(docs)
+    start = docs[0][1]
+    stop = docs[-1][1]
+
+    def doc_gen():
+        yield from docs
+
+    catalog.upsert(start, stop, doc_gen, [], {})
+
+    print(list(catalog[-1]))
+    assert catalog[-1]['primary'].to_dask()['raw'].compute().shape == (1, *data_shape)
+
+
+@pytest.mark.parametrize("multi_descriptor_doc_stream", (["primary", "baseline"],), indirect=True)
+def test_multi_descriptors_unique(multi_descriptor_doc_stream):
+    _test_ingest_to_xarray(multi_descriptor_doc_stream)
+
+
+@pytest.mark.parametrize("multi_descriptor_doc_stream", (["primary", "primary"],), indirect=True)
+def test_multi_descriptors_same(multi_descriptor_doc_stream):
+    _test_ingest_to_xarray(multi_descriptor_doc_stream)
+

--- a/databroker/tests/test_v2/test_multi_descriptor.py
+++ b/databroker/tests/test_v2/test_multi_descriptor.py
@@ -13,8 +13,6 @@ def multi_descriptor_doc_stream(request):
     streams = request.param
     def doc_gen(stream_names):
 
-        print('names:', stream_names)
-
         # Compose run start
         run_bundle = event_model.compose_run()  # type: event_model.ComposeRunBundle
         start_doc = run_bundle.start_doc
@@ -45,7 +43,6 @@ def multi_descriptor_doc_stream(request):
 def _test_ingest_to_xarray(stream):
     docs = list(stream)
     catalog = BlueskyInMemoryCatalog()
-    print(docs)
     start = docs[0][1]
     stop = docs[-1][1]
 
@@ -54,7 +51,6 @@ def _test_ingest_to_xarray(stream):
 
     catalog.upsert(start, stop, doc_gen, [], {})
 
-    print(list(catalog[-1]))
     assert catalog[-1]['primary'].to_dask()['raw'].compute().shape == (1, *data_shape)
 
 

--- a/databroker/tests/test_v2/test_multi_descriptor.py
+++ b/databroker/tests/test_v2/test_multi_descriptor.py
@@ -27,23 +27,17 @@ def multi_descriptor_doc_stream(request):
 
             # Compose descriptor
             source = "NCEM"
-            if with_dims:
-                frame_data_keys = {
-                    "raw": {
-                        "source": source,
-                        "dtype": "array",
-                        "shape": data.shape,
-                        "dims": ("x", "y"),
-                    }
+            frame_data_keys = {
+                "raw": {
+                    "source": source,
+                    "dtype": "array",
+                    "shape": data.shape,
+                    "dims": ("x", "y"),
                 }
-            else:
-                frame_data_keys = {
-                    "raw": {
-                        "source": source,
-                        "dtype": "array",
-                        "shape": data.shape,
-                    }
-                }
+            }
+            if not with_dims:
+                del frame_data_keys['dims']
+
             frame_stream_bundle = run_bundle.compose_descriptor(
                 data_keys=frame_data_keys, name=stream_name,
             )

--- a/databroker/tests/test_v2/test_multi_descriptor.py
+++ b/databroker/tests/test_v2/test_multi_descriptor.py
@@ -36,7 +36,7 @@ def multi_descriptor_doc_stream(request):
                 }
             }
             if not with_dims:
-                del frame_data_keys['dims']
+                del frame_data_keys['raw']['dims']
 
             frame_stream_bundle = run_bundle.compose_descriptor(
                 data_keys=frame_data_keys, name=stream_name,


### PR DESCRIPTION
This demonstrates a failure when multiple descriptors of the same name are present. 

One test succeeds, while the other fails with:
```
databroker\tests\test_v2\test_multi_descriptor.py:65 (test_multi_descriptors_same[multi_descriptor_doc_stream0])
multi_descriptor_doc_stream = <generator object multi_descriptor_doc_stream.<locals>.doc_gen at 0x00000254199AF048>

    @pytest.mark.parametrize("multi_descriptor_doc_stream", (["primary", "primary"],), indirect=True)
    def test_multi_descriptors_same(multi_descriptor_doc_stream):
>       _test_ingest_to_xarray(multi_descriptor_doc_stream)

test_multi_descriptor.py:68: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
test_multi_descriptor.py:58: in _test_ingest_to_xarray
    assert catalog[-1]['primary'].to_dask()['raw'].compute().shape == (1, *data_shape)
..\..\core.py:1372: in to_dask
    return super().to_dask()
..\..\intake_xarray_core\base.py:77: in to_dask
    return self.read_chunked()
..\..\intake_xarray_core\base.py:53: in read_chunked
    self._load_metadata()
C:\Users\LBL\.virtualenvs\merged-repo\lib\site-packages\intake\source\base.py:117: in _load_metadata
    self._schema = self._get_schema()
..\..\intake_xarray_core\base.py:20: in _get_schema
    self._open_dataset()
..\..\core.py:1355: in _open_dataset
    exclude=self.exclude)
..\..\core.py:719: in _documents_to_xarray
    return xarray.merge(datasets)
C:\Users\LBL\.virtualenvs\merged-repo\lib\site-packages\xarray\core\merge.py:793: in merge
    merge_result = merge_core(dict_like_objects, compat, join, fill_value=fill_value)
C:\Users\LBL\.virtualenvs\merged-repo\lib\site-packages\xarray\core\merge.py:555: in merge_core
    variables, out_indexes = merge_collected(collected, prioritized, compat=compat)
C:\Users\LBL\.virtualenvs\merged-repo\lib\site-packages\xarray\core\merge.py:228: in merge_collected
    merged_vars[name] = unique_variable(name, variables, compat)
C:\Users\LBL\.virtualenvs\merged-repo\lib\site-packages\xarray\core\merge.py:137: in unique_variable
    equals = getattr(out, compat)(var)
C:\Users\LBL\.virtualenvs\merged-repo\lib\site-packages\xarray\core\variable.py:1722: in no_conflicts
    return self.broadcast_equals(other, equiv=equiv)
C:\Users\LBL\.virtualenvs\merged-repo\lib\site-packages\xarray\core\variable.py:1703: in broadcast_equals
    return self.equals(other, equiv=equiv)
C:\Users\LBL\.virtualenvs\merged-repo\lib\site-packages\xarray\core\variable.py:1687: in equals
    self._data is other._data or equiv(self.data, other.data)
C:\Users\LBL\.virtualenvs\merged-repo\lib\site-packages\xarray\core\duck_array_ops.py:234: in array_notnull_equiv
    flag_array = (arr1 == arr2) | isnull(arr1) | isnull(arr2)
C:\Users\LBL\.virtualenvs\merged-repo\lib\site-packages\dask\array\core.py:1833: in __eq__
    return elemwise(operator.eq, self, other)
C:\Users\LBL\.virtualenvs\merged-repo\lib\site-packages\dask\array\core.py:3910: in elemwise
    name = kwargs.get("name", None) or "%s-%s" % (funcname(op), tokenize(op, dt, *args))
C:\Users\LBL\.virtualenvs\merged-repo\lib\site-packages\dask\base.py:658: in tokenize
    return md5(str(tuple(map(normalize_token, args))).encode()).hexdigest()
C:\Users\LBL\.virtualenvs\merged-repo\lib\site-packages\dask\utils.py:506: in __call__
    return meth(arg, *args, **kwargs)
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

x = array([[[[[0.73661346, 0.73661346, 0.73661346, ..., 0.73661346,
           0.73661346, 0.73661346],
          [0.73661...n,        nan],
          [       nan,        nan,        nan, ...,        nan,
                  nan,        nan]]]]])

    @normalize_token.register(np.ndarray)
    def normalize_array(x):
        if not x.shape:
            return (x.item(), x.dtype)
        if hasattr(x, "mode") and getattr(x, "filename", None):
            if hasattr(x.base, "ctypes"):
                offset = (
                    x.ctypes.get_as_parameter().value
                    - x.base.ctypes.get_as_parameter().value
                )
            else:
                offset = 0  # root memmap's have mmap object as base
            if hasattr(
                x, "offset"
            ):  # offset numpy used while opening, and not the offset to the beginning of the file
                offset += getattr(x, "offset")
            return (
                x.filename,
                os.path.getmtime(x.filename),
                x.dtype,
                x.shape,
                x.strides,
                offset,
            )
        if x.dtype.hasobject:
            try:
                try:
                    # string fast-path
                    data = hash_buffer_hex(
                        "-".join(x.flat).encode(
                            encoding="utf-8", errors="surrogatepass"
                        )
                    )
                except UnicodeDecodeError:
                    # bytes fast-path
                    data = hash_buffer_hex(b"-".join(x.flat))
            except (TypeError, UnicodeDecodeError):
                try:
                    data = hash_buffer_hex(pickle.dumps(x, pickle.HIGHEST_PROTOCOL))
                except Exception:
                    # pickling not supported, use UUID4-based fallback
                    data = uuid.uuid4().hex
        else:
            try:
>               data = hash_buffer_hex(x.ravel(order="K").view("i1"))
E               MemoryError: Unable to allocate 14.6 TiB for an array with shape (2000000000000,) and data type float64

C:\Users\LBL\.virtualenvs\merged-repo\lib\site-packages\dask\base.py:878: MemoryError
```