### PR TITLE
Prevent recursion back to same catalog when looking for attrs

### DIFF
--- a/databroker/core.py
+++ b/databroker/core.py
@@ -1144,7 +1144,8 @@ class BlueskyRun(intake.catalog.Catalog):
             if key != "_entry" and self._entry.name != self.name:
                 return getattr(self._entry, key)
             else:
-                raise AttributeError("Aborted before recursing back to self.") from ex
+                # Aborted before recursing back to self.
+                raise AttributeError(self) from ex
 
     def canonical(self, *, fill, strict_order=True):
         yield from _canonical(start=self.metadata['start'],

--- a/databroker/core.py
+++ b/databroker/core.py
@@ -1142,7 +1142,6 @@ class BlueskyRun(intake.catalog.Catalog):
             # The user might be trying to access an Entry method. Try that
             # before giving up.
             if key != "_entry" and self._entry.name != self.name:
-                print(self._entry.name, self.name)
                 return getattr(self._entry, key)
             else:
                 raise AttributeError("Aborted before recursing back to self.") from ex

--- a/databroker/core.py
+++ b/databroker/core.py
@@ -1138,10 +1138,14 @@ class BlueskyRun(intake.catalog.Catalog):
             # Let the base classes try to handle it first. This will handle,
             # for example, accessing subcatalogs using dot-access.
             return super().__getattr__(key)
-        except AttributeError:
+        except AttributeError as ex:
             # The user might be trying to access an Entry method. Try that
             # before giving up.
-            return getattr(self._entry, key)
+            if key != "_entry" and self._entry.name != self.name:
+                print(self._entry.name, self.name)
+                return getattr(self._entry, key)
+            else:
+                raise AttributeError("Aborted before recursing back to self.") from ex
 
     def canonical(self, *, fill, strict_order=True):
         yield from _canonical(start=self.metadata['start'],


### PR DESCRIPTION
This PR addresses an issue with `BlueskyRun.__getattr__` that causes infinite recursion. When a key is not present on a BR, it's `._entry` is queried as well. Often, `._entry` ends up being the same BR. This checks for that case, and raises before continuing to `._entry`.