### PR TITLE
Adjust for Entry unification

### DIFF
--- a/databroker/core.py
+++ b/databroker/core.py
@@ -29,7 +29,6 @@ from .intake_xarray_core.xarray_container import RemoteXarray
 from .utils import LazyMap
 from collections import deque, OrderedDict
 from dask.base import normalize_token
-from intake.utils import DictSerialiseMixin
 
 
 logger = logging.getLogger(__name__)
@@ -255,7 +254,6 @@ class Entry(intake.catalog.local.LocalCatalogEntry):
     #     print('bob')
     #     metadata = self.describe()['metadata']
     #     return ('Entry', metadata['start']['uid'])
-
 
 
 class StreamEntry(Entry):
@@ -825,7 +823,9 @@ class RemoteBlueskyRun(intake.catalog.base.RemoteCatalog):
     kwargs: ignored
     """
     name = 'bluesky-run'
+
     # opt-out of the persistence features of intake
+
     @property
     def has_been_persisted(self):
         return False

--- a/databroker/core.py
+++ b/databroker/core.py
@@ -251,6 +251,12 @@ class Entry(intake.catalog.local.LocalCatalogEntry):
             self.__cache[token] = datasource
         return datasource
 
+    # def __dask_tokenize__(self):
+    #     print('bob')
+    #     metadata = self.describe()['metadata']
+    #     return ('Entry', metadata['start']['uid'])
+
+
 
 class StreamEntry(Entry):
     """
@@ -259,6 +265,11 @@ class StreamEntry(Entry):
     def _make_cache(self):
         return dict()
 
+    # def __dask_tokenize__(self):
+    #     print('bill')
+    #     metadata = self.describe()['metadata']
+    #     print(self.describe())
+    #     return ('Stream', metadata['start']['uid'], self.name)
 
 
 def to_event_pages(get_event_cursor, page_size):
@@ -837,6 +848,10 @@ class RemoteBlueskyRun(intake.catalog.base.RemoteCatalog):
     def pmode(self, val):
         ...
 
+    # def __dask_tokenize__(self):
+    #     print('baz')
+    #     return ('RemoteBlueskyRun', self.metadata['start']['uid'])
+
     def __init__(self, url, http_args, name, parameters, metadata=None, **kwargs):
         self.url = url
         self.name = name
@@ -1001,6 +1016,11 @@ class BlueskyRun(intake.catalog.Catalog):
     @pmode.setter
     def pmode(self, val):
         ...
+
+    # def __dask_tokenize__(self):
+    #     print('baz')
+    #     return ('BlueksyRun', self.metadata['start']['uid'])
+
     container = 'bluesky-run'
     version = '0.0.1'
     partition_access = True
@@ -1309,6 +1329,11 @@ class BlueskyEventStream(DataSourceMixin):
     **kwargs :
         Additional keyword arguments are passed through to the base class.
     """
+
+    # def __dask_tokenize__(self):
+    #     print('bill')
+    #     intake_desc = self.describe()
+    #     return ('Stream', intake_desc['metadata']['start']['uid'], metadata['name'])
     # opt-out of the persistence features of intake
     @property
     def has_been_persisted(self):
@@ -1331,6 +1356,7 @@ class BlueskyEventStream(DataSourceMixin):
     @_pmode.setter
     def _pmode(self, val):
         ...
+
     container = 'bluesky-event-stream'
     version = '0.0.1'
     partition_access = True

--- a/databroker/core.py
+++ b/databroker/core.py
@@ -209,6 +209,7 @@ class Entry(intake.catalog.local.LocalCatalogEntry):
         # This cache holds datasources, the result of calling super().get(...)
         # with potentially different arguments.
         self.__cache = self._make_cache()
+        self.entry = self
         logger.debug("Created Entry named %r", self.name)
 
     def _make_cache(self):

--- a/databroker/core.py
+++ b/databroker/core.py
@@ -1190,17 +1190,7 @@ class BlueskyRun(intake.catalog.Catalog):
             self.__class__.__name__,
             self.__entry.name)
 
-    def get(self, *args, **kwargs):
-        """
-        Return self or, if args are provided, some new instance of type(self).
-
-        This is here so that the user does not have to remember whether a given
-        variable is a BlueskyRun or an *Entry* with a Bluesky Run. In either
-        case, ``obj.get()`` will return a BlueskyRun.
-        """
-        return self.__entry.get(*args, **kwargs)
-
-    def __call__(self, *args, **kwargs):
+    def configure_new(self, **kwargs):
         """
         Return self or, if args are provided, some new instance of type(self).
 
@@ -1208,7 +1198,9 @@ class BlueskyRun(intake.catalog.Catalog):
         variable is a BlueskyRun or an *Entry* with a Bluesky Run. In either
         case, ``obj()`` will return a BlueskyRun.
         """
-        return self.get(*args, **kwargs)
+        return self.__entry.get(**kwargs)
+
+    get = __call__ = configure_new
 
     def __getattr__(self, key):
         try:
@@ -1985,8 +1977,8 @@ def parse_transforms(transforms):
     --------
     Pass in name; get back actual class.
 
-    >>> parse_transforms({'descriptor': 'package.module.ClassName'})
-    {'descriptor': <package.module.ClassName>}
+    >>> parse_transforms({'descriptor': 'package.module.function_name'})
+    {'descriptor': <package.module.function_name>}
 
     """
     transformable = {'start', 'stop', 'resource', 'descriptor'}

--- a/databroker/core.py
+++ b/databroker/core.py
@@ -250,13 +250,6 @@ class StreamEntry(Entry):
     def _make_cache(self):
         return dict()
 
-    def __getstate__(self):
-        args = [arg.__getstate__() if isinstance(arg, DictSerialiseMixin)
-                else arg for arg in self._captured_init_args]
-        kwargs = OrderedDict({k: arg.__getstate__()
-                              if isinstance(arg, DictSerialiseMixin) else arg
-                              for k, arg in self._captured_init_kwargs.items()})
-        return OrderedDict(cls=self.classname, args=args, kwargs=kwargs)
 
 
 def to_event_pages(get_event_cursor, page_size):

--- a/databroker/core.py
+++ b/databroker/core.py
@@ -986,10 +986,9 @@ class BlueskyRun(intake.catalog.Catalog):
         self.fillers['no'] = event_model.NoFiller(
             self.fillers['yes'].handler_registry, inplace=True)
         self.fillers['delayed'] = get_filler(coerce='delayed')
-        self._entry = entry
         self._transforms = transforms
         self._run_stop_doc = None
-
+        self.__entry = entry
         super().__init__(**kwargs)
         logger.debug(
             "Created %s named %r",
@@ -1111,7 +1110,7 @@ class BlueskyRun(intake.catalog.Catalog):
         logger.debug(
             "Loaded %s named %r",
             self.__class__.__name__,
-            self._entry.name)
+            self.__entry.name)
 
     def get(self, *args, **kwargs):
         """
@@ -1121,7 +1120,7 @@ class BlueskyRun(intake.catalog.Catalog):
         variable is a BlueskyRun or an *Entry* with a Bluesky Run. In either
         case, ``obj.get()`` will return a BlueskyRun.
         """
-        return self._entry.get(*args, **kwargs)
+        return self.__entry.get(*args, **kwargs)
 
     def __call__(self, *args, **kwargs):
         """
@@ -1141,7 +1140,7 @@ class BlueskyRun(intake.catalog.Catalog):
         except AttributeError:
             # The user might be trying to access an Entry method. Try that
             # before giving up.
-            return getattr(self._entry, key)
+            return getattr(self.__entry, key)
 
     def canonical(self, *, fill, strict_order=True):
         yield from _canonical(start=self.metadata['start'],

--- a/databroker/core.py
+++ b/databroker/core.py
@@ -1202,16 +1202,6 @@ class BlueskyRun(intake.catalog.Catalog):
 
     get = __call__ = configure_new
 
-    def __getattr__(self, key):
-        try:
-            # Let the base classes try to handle it first. This will handle,
-            # for example, accessing subcatalogs using dot-access.
-            return super().__getattr__(key)
-        except AttributeError:
-            # The user might be trying to access an Entry method. Try that
-            # before giving up.
-            return getattr(self.__entry, key)
-
     def canonical(self, *, fill, strict_order=True):
         yield from _canonical(start=self.metadata['start'],
                               stop=self.metadata['stop'],

--- a/databroker/core.py
+++ b/databroker/core.py
@@ -201,6 +201,15 @@ class PartitionIndexError(IndexError):
 
 
 class Entry(intake.catalog.local.LocalCatalogEntry):
+
+    @property
+    def _pmode(self):
+        return 'never'
+
+    @_pmode.setter
+    def _pmode(self, val):
+        ...
+
     def __init__(self, **kwargs):
         # This might never come up, but just to be safe....
         if 'entry' in kwargs['args']:
@@ -805,6 +814,28 @@ class RemoteBlueskyRun(intake.catalog.base.RemoteCatalog):
     kwargs: ignored
     """
     name = 'bluesky-run'
+    # opt-out of the persistence features of intake
+    @property
+    def has_been_persisted(self):
+        return False
+
+    @property
+    def is_persisted(self):
+        return False
+
+    def get_persisted(self):
+        raise KeyError("Does not support intake persistence")
+
+    def persist(self, *args, **kwargs):
+        raise NotImplementedError
+
+    @property
+    def pmode(self):
+        return 'never'
+
+    @pmode.setter
+    def pmode(self, val):
+        ...
 
     def __init__(self, url, http_args, name, parameters, metadata=None, **kwargs):
         self.url = url
@@ -819,6 +850,8 @@ class RemoteBlueskyRun(intake.catalog.base.RemoteCatalog):
         super().__init__(url=url, http_args=http_args, name=name,
                          metadata=metadata,
                          source_id=self._source_id)
+        # turn off any attempts at persistence
+        self._pmode = "never"
         self.npartitions = response['npartitions']
         self.metadata = response['metadata']
         self._schema = intake.source.base.Schema(
@@ -946,6 +979,28 @@ class BlueskyRun(intake.catalog.Catalog):
         Additional keyword arguments are passed through to the base class,
         Catalog.
     """
+    # opt-out of the persistence features of intake
+    @property
+    def has_been_persisted(self):
+        return False
+
+    @property
+    def is_persisted(self):
+        return False
+
+    def get_persisted(self):
+        raise KeyError("Does not support intake persistence")
+
+    def persist(self, *args, **kwargs):
+        raise NotImplementedError
+
+    @property
+    def pmode(self):
+        return 'never'
+
+    @pmode.setter
+    def pmode(self, val):
+        ...
     container = 'bluesky-run'
     version = '0.0.1'
     partition_access = True
@@ -987,7 +1042,9 @@ class BlueskyRun(intake.catalog.Catalog):
         self._transforms = transforms
         self._run_stop_doc = None
         self.__entry = entry
-        super().__init__(**kwargs)
+        super().__init__(**{**kwargs, 'persist_mode': 'never'})
+        # turn off any attempts at persistence
+        self._pmode = "never"
         logger.debug(
             "Created %s named %r",
             self.__class__.__name__,
@@ -1252,6 +1309,28 @@ class BlueskyEventStream(DataSourceMixin):
     **kwargs :
         Additional keyword arguments are passed through to the base class.
     """
+    # opt-out of the persistence features of intake
+    @property
+    def has_been_persisted(self):
+        return False
+
+    @property
+    def is_persisted(self):
+        return False
+
+    def get_persisted(self):
+        raise KeyError("Does not support intake persistence")
+
+    def persist(self, *args, **kwargs):
+        raise NotImplementedError
+
+    @property
+    def _pmode(self):
+        return 'never'
+
+    @_pmode.setter
+    def _pmode(self, val):
+        ...
     container = 'bluesky-event-stream'
     version = '0.0.1'
     partition_access = True
@@ -1292,7 +1371,8 @@ class BlueskyEventStream(DataSourceMixin):
         self._partitions = None
 
         super().__init__(metadata=metadata, **kwargs)
-
+        # turn off any attempts at persistence
+        self._pmode = "never"
         self._run_stop_doc = metadata['stop']
         self._run_start_doc = metadata['start']
         self._load_header()

--- a/databroker/core.py
+++ b/databroker/core.py
@@ -1555,9 +1555,6 @@ class SingleRunCache:
         erroneous metadata. It is intended for quick, temporary fixes that
         may later be applied permanently to the data at rest
         (e.g., via a database migration).
-    **kwargs:
-        Additional keyword arguments are passed through to the base class,
-        Catalog.
 
     Examples
     --------
@@ -1576,7 +1573,7 @@ class SingleRunCache:
 
     """
     def __init__(self, *, handler_registry=None, root_map=None,
-                 filler_class=event_model.Filler, transforms=None, **kwargs):
+                 filler_class=event_model.Filler, transforms=None):
 
         self._root_map = root_map or {}
         self._filler_class = filler_class

--- a/databroker/core.py
+++ b/databroker/core.py
@@ -212,6 +212,10 @@ class Entry(intake.catalog.local.LocalCatalogEntry):
         self.entry = self
         logger.debug("Created Entry named %r", self.name)
 
+    @property
+    def catalog(self):
+        return self._catalog
+
     def _make_cache(self):
         return cachetools.LRUCache(10)
 

--- a/databroker/core.py
+++ b/databroker/core.py
@@ -1070,6 +1070,9 @@ class BlueskyRun(intake.catalog.Catalog):
             self.__class__.__name__,
             entry.name)
 
+    def describe(self):
+        return self.__entry.describe()
+
     def __repr__(self):
         try:
             self._load()

--- a/databroker/tests/test_glue.py
+++ b/databroker/tests/test_glue.py
@@ -1,8 +1,8 @@
-import sys
 import pytest
 
 
 def test_glue(db, RE):
+    pytest.importorskip('glue')
     from databroker.glue import read_header
     from glue.qglue import parse_data
     import bluesky.plans as bp

--- a/databroker/v1.py
+++ b/databroker/v1.py
@@ -322,8 +322,8 @@ class Broker:
                                  "and could become too large.")
             return [self[index]
                     for index in reversed(range(key.start, key.stop or 0, key.step or 1))]
-        entry = self._catalog[key]
-        return Header(entry)
+        datasource = self._catalog[key]
+        return Header(datasource)
 
     get_fields = staticmethod(get_fields)
 
@@ -983,20 +983,18 @@ class Header:
     """
     This supports the original Header API but implemented on intake's Entry.
     """
-    def __init__(self, entry):
-        self._entry = entry
-        self.__data_source = None
-        self.db = entry.catalog.v1
+    def __init__(self, datasource):
+        self.__data_source = datasource
+        self.db = datasource.catalog_object.v1
         self.ext = None  # TODO
-        self._start = entry.describe()['metadata']['start']
-        self._stop = entry.describe()['metadata']['stop']
+        md = datasource.describe()['metadata']
+        self._start = md['start']
+        self._stop = md['stop']
         self.ext = SimpleNamespace(
             **self.db.fetch_external(self.start, self.stop))
 
     @property
     def _data_source(self):
-        if self.__data_source is None:
-            self.__data_source = self._entry.get()
         return self.__data_source
 
     @property
@@ -1010,7 +1008,7 @@ class Header:
     @property
     def stop(self):
         if self._stop is None:
-            self._stop = self._entry.describe()['metadata']['stop'] or {}
+            self._stop = self.__data_source.describe()['metadata']['stop'] or {}
         return self.db.prepare_hook('stop', self._stop)
 
     def __eq__(self, other):
@@ -1024,8 +1022,7 @@ class Header:
 
     @property
     def stream_names(self):
-        catalog = self._entry()
-        return list(catalog)
+        return list(self.__data_source)
 
     # These methods mock part of the dict interface. It has been proposed that
     # we might remove them for 1.0.
@@ -1403,7 +1400,7 @@ class Results:
     def __iter__(self):
         # TODO Catalog.walk() fails. We should probably support Catalog.items().
         for uid, entry in self._catalog._entries.items():
-            header = Header(entry)
+            header = Header(entry())
             if self._data_key is None:
                 yield header
             else:

--- a/databroker/v1.py
+++ b/databroker/v1.py
@@ -986,7 +986,7 @@ class Header:
     def __init__(self, entry):
         self._entry = entry
         self.__data_source = None
-        self.db = entry.catalog_object.v1
+        self.db = entry.catalog.v1
         self.ext = None  # TODO
         self._start = entry.describe()['metadata']['start']
         self._stop = entry.describe()['metadata']['stop']

--- a/doc/source/v1/tutorial.rst
+++ b/doc/source/v1/tutorial.rst
@@ -98,7 +98,7 @@ DataFrames can be used to perform fast computations on labeled data, such as
 .. ipython:: python
 
     t = header.table()
-    t.mean()
+    t.mean(numeric_only=True)
     t['det'] / t['motor']
 
 or export to a file.


### PR DESCRIPTION
This PR adjust for changes in intake that will be introduced in
intake/intake#490. This branch has been tested against that PR branch, as well
as intake `master` and the most recent intake release, `0.5.5`.

This is how it looks interactively against that PR branch:

```py
In [1]: import databroker                                                                                                                                                                     

In [3]: list(databroker.catalog)                                                                                                                                                              
Out[3]: 
['dev1',
 'dev2',
 'fxi_feb',
 'test1',
 'test_unpack1',
 'test_unpack3',
 'dev',
 'csx',
 'example']

In [4]: databroker.catalog.dev1                                                                                                                                                               
Out[4]: <Intake catalog: dev1>  # <--- NOT AN ENTRY ANYMORE

In [5]: type(databroker.catalog.dev1)                                                                                                                                                         
Out[5]: databroker._drivers.msgpack.BlueskyMsgpackCatalog
```