### PR TITLE
FIX: if no stop document don't emit None

### DIFF
--- a/databroker/core.py
+++ b/databroker/core.py
@@ -782,8 +782,8 @@ def _canonical(*, start, stop, entries, fill, strict_order=True):
 
         else:
             yield (name, doc)
-
-    yield ('stop', stop)
+    if stop is not None:
+        yield ('stop', stop)
 
 
 class RemoteBlueskyRun(intake.catalog.base.RemoteCatalog):


### PR DESCRIPTION
If we don't have a stop document, the `run.metadata['stop'] is None` which seems reasonable, we don't have a value for it yet and it is up to the consumer to do something sensible in this case.

However, when we call `run.cannonical()` we expect valid `(name, doc)` pairs.  Previously we were yielding out the `None` which was causing downstream tools to choke.

A better solution may be to keep a running count of the event/event_page documents and fabricate a missing stop document.  That does require a bit more thought as to what the exit status should be.