### PR TITLE
Test for AttributeError vs RecursionError.

### DIFF
--- a/databroker/tests/test_v2/generic.py
+++ b/databroker/tests/test_v2/generic.py
@@ -297,3 +297,10 @@ def test_metadata_keys(bundle):
 
     stream_metadata = run['primary']().metadata
     assert 'descriptors' in stream_metadata
+
+
+def test_infinite_recursion_bug(bundle):
+    run = bundle.cat['xyz']()[bundle.uid]()
+    with pytest.raises(AttributeError):
+        # used to raise RecursionErrror
+        run.does_not_exist


### PR DESCRIPTION
The bug in question was fixed in the course of finishing #569. This just adds
a test to ensure it does not creep back in.