### PR TITLE
Add test for 'stats' method and further document it.

### DIFF
--- a/databroker/tests/test_v2/test_mongo_normalized.py
+++ b/databroker/tests/test_v2/test_mongo_normalized.py
@@ -107,3 +107,15 @@ def test_find_kwargs(bundle):
         results = cat['xyz'].search({'plan_name': 'scan'},
                                     NOT_A_VALID_PARAMETER=None)
         list(results)  # needed to trigger Cursor instantiation in local case
+
+
+def test_stats(bundle):
+    "Test the method stats which gives MongoDB database data usage info"
+    cat = bundle.cat['xyz']
+    if bundle.remote:
+        # Not supported on remote catalogs; remote users shouldn't be allowed
+        # to see this info.
+        assert not hasattr(cat, "stats")
+    else:
+        assert 'storageSize' in cat.stats()  # check an example key
+        assert 'storageSize' in cat.v1.stats()  # check an example key

--- a/doc/source/v1/api.rst
+++ b/doc/source/v1/api.rst
@@ -253,6 +253,7 @@ Configuration Utilities
    temp
    Broker.name
    Broker.get_config
+   Broker.stats
 
 Back- and Forward-Compat Accessors
 ----------------------------------


### PR DESCRIPTION
The new `stats()` method introduced in #584 was (automatically) documented in
the v2 reference documentation, but because of the way v1 documentation is
organized it had to be manually added there.

Also, while I was here I added a unit test for `stats()`.