### PR TITLE
More shape extraction heuristics.

### DIFF
--- a/databroker/core.py
+++ b/databroker/core.py
@@ -2069,7 +2069,7 @@ def extract_shape(descriptor, key, resource=None):
     Patch up misreported 'shape' metadata in old documents.
 
     This uses heuristcs to guess if the shape looks wrong and determine the
-    right one. Once historical data has been fixed, this function will will be
+    right one. Once historical data has been fixed, this function will be
     reused to::
 
     return descriptor['data_keys'][key]['shape']

--- a/databroker/core.py
+++ b/databroker/core.py
@@ -2061,7 +2061,7 @@ def coerce_dask(handler_class, filler_state):
 # By adding it via plugin, we avoid adding a dask.array dependency to
 # event-model and we keep the fiddly hacks into extract_shape here in
 # databroker, a faster-moving and less fundamental library than event-model.
-event_model.register_coersion('delayed', coerce_dask)
+event_model.register_coercion('delayed', coerce_dask)
 
 
 def extract_shape(descriptor, key, resource=None):

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ boltons
 cachetools
 dask[array,bag]
 doct
-event-model >=1.14.0
+event-model >=1.16.0
 humanize
 intake >=0.5.5
 jinja2


### PR DESCRIPTION
We use `extract_shape` to work around the fact that many old documents have
wrong shape metadata. Until we go back and fix old documents, this is how we can
make them readable by "v2", which unlike "v1" relies on `shape` actually being
accurate.

Needs a new event-model release and an increased minimum version pin.