### PR TITLE
add EventDatumNotFound exception

### DIFF
--- a/databroker/_core.py
+++ b/databroker/_core.py
@@ -26,7 +26,7 @@ from .utils import (ALL, get_fields, wrap_in_deprecated_doct, wrap_in_doct,
                     DeprecatedDoct, DOCT_NAMES, lookup_config, list_configs,
                     describe_configs, SPECIAL_NAME)
 
-from databroker.assets.core import DatumNotFound
+from databroker.assets.core import DatumNotFound, EventDatumNotFound
 
 
 try:
@@ -1427,12 +1427,10 @@ class BrokerES(object):
                                         yield 'datum', self.prepare_hook(name,
                                                                          datum)
                                     except DatumNotFound as dnf:
-                                        logger.exception(
-                                            'Event %s references missing Datum %s',
-                                            doc["uid"],
-                                            v
-                                        )
-                                        raise dnf
+                                        raise EventDatumNotFound(
+                                            event_uid=doc["uid"],
+                                            datum_id=dnf.datum_id
+                                        ) from dnf
 
                             doc = proc_gen.send(doc)
 

--- a/databroker/assets/core.py
+++ b/databroker/assets/core.py
@@ -15,7 +15,7 @@ class DatumNotFound(Exception):
     Raised if a Datum id is not found.
     """
     def __init__(self, datum_id, *args, **kwargs):
-        self.super(*args, **kwargs)
+        super(*args, **kwargs)
         self.datum_id = datum_id
 
     def __str__(self):
@@ -27,7 +27,7 @@ class EventDatumNotFound(Exception):
     Raised if an Event document is found to have an unknown Datum id.
     """
     def __init__(self, event_uid, datum_id, *args, **kwargs):
-        self.super(*args, **kwargs)
+        super(*args, **kwargs)
         self.event_uid = event_uid
         self.datum_id = datum_id
 

--- a/databroker/assets/core.py
+++ b/databroker/assets/core.py
@@ -9,8 +9,33 @@ import time as ttime
 import pandas as pd
 from ..utils import sanitize_np, apply_to_dict_recursively
 
+
 class DatumNotFound(Exception):
-    pass
+    """
+    Raised if a Datum id is not found.
+    """
+    def __init__(self, datum_id, *args, **kwargs):
+        self.super(*args, **kwargs)
+        self.datum_id = datum_id
+
+    def __str__(self):
+        return f"No datum found with datum id {self.datum_id}"
+
+
+class EventDatumNotFound(Exception):
+    """
+    Raised if an Event document is found to have an unknown Datum id.
+    """
+    def __init__(self, event_uid, datum_id, *args, **kwargs):
+        self.super(*args, **kwargs)
+        self.event_uid = event_uid
+        self.datum_id = datum_id
+
+    def __str__(self):
+        return (
+            f"Event with uid {self.event_uid} references "
+            f"unknown Datum with datum id {self.datum_id}"
+        )
 
 
 def doc_or_uid_to_uid(doc_or_uid):
@@ -40,8 +65,7 @@ def _get_datum_from_datum_id(col, datum_id, datum_cache, logger):
         # find the current document
         edoc = col.find_one({'datum_id': datum_id})
         if edoc is None:
-            raise DatumNotFound(
-                "No datum found with datum_id {!r}".format(datum_id))
+            raise DatumNotFound(datum_id=datum_id)
         # save it for later
         datum = dict(edoc)
 

--- a/databroker/assets/core.py
+++ b/databroker/assets/core.py
@@ -14,8 +14,8 @@ class DatumNotFound(Exception):
     """
     Raised if a Datum id is not found.
     """
-    def __init__(self, datum_id, *args, **kwargs):
-        super(*args, **kwargs)
+    def __init__(self, datum_id, *args):
+        super().__init__(*args)
         self.datum_id = datum_id
 
     def __str__(self):
@@ -26,8 +26,8 @@ class EventDatumNotFound(Exception):
     """
     Raised if an Event document is found to have an unknown Datum id.
     """
-    def __init__(self, event_uid, datum_id, *args, **kwargs):
-        super(*args, **kwargs)
+    def __init__(self, event_uid, datum_id, *args):
+        super().__init__(*args)
         self.event_uid = event_uid
         self.datum_id = datum_id
 

--- a/databroker/assets/core.py
+++ b/databroker/assets/core.py
@@ -14,28 +14,26 @@ class DatumNotFound(Exception):
     """
     Raised if a Datum id is not found.
     """
-    def __init__(self, datum_id, *args):
-        super().__init__(*args)
+    def __init__(self, datum_id, msg=None, *args):
+        if msg is None:
+            msg = f"No datum found with datum id {datum_id}"
+        super().__init__(msg, *args)
         self.datum_id = datum_id
-
-    def __str__(self):
-        return f"No datum found with datum id {self.datum_id}"
 
 
 class EventDatumNotFound(Exception):
     """
     Raised if an Event document is found to have an unknown Datum id.
     """
-    def __init__(self, event_uid, datum_id, *args):
-        super().__init__(*args)
+    def __init__(self, event_uid, datum_id, msg=None, *args):
+        if msg is None:
+            msg = (
+                f"Event with uid {event_uid} references "
+                f"unknown Datum with datum id {datum_id}"
+            )
+        super().__init__(msg, *args)
         self.event_uid = event_uid
         self.datum_id = datum_id
-
-    def __str__(self):
-        return (
-            f"Event with uid {self.event_uid} references "
-            f"unknown Datum with datum id {self.datum_id}"
-        )
 
 
 def doc_or_uid_to_uid(doc_or_uid):

--- a/databroker/core.py
+++ b/databroker/core.py
@@ -1839,13 +1839,14 @@ def _transpose(in_data, keys, field):
             # TEMPORARY EMERGENCY FALLBACK
             # If environment variable is set to anything but 0, work around
             # dask and return a numpy array.
-            if os.environ.get('DATABROKER_ARRAY_FALLBACK') != "0":
+            databroker_array_fallback = os.environ.get('DATABROKER_ARRAY_FALLBACK')
+            if databroker_array_fallback != "0":
                 out[k] = numpy.asarray(out[k])
                 warnings.warn(
                     f"Creating a dask array raised an error. Because the "
                     f"environment variable DATABROKER_ARRAY_FALLBACK was set "
-                    f"to {switch} we have caught the error and fallen "
-                    f"back to returning a numpy array instead. This may be "
+                    f"to {databroker_array_fallback} we have caught the error and "
+                    f"fallen back to returning a numpy array instead. This may be "
                     f"very slow. The underlying issue should be resolved. The "
                     f"error was {err!r}.")
             else:


### PR DESCRIPTION
Debugging problems resulting in DatumNotFound exceptions is made easier if the corresponding event can be quickly found.

This PR adds EventDatumNotFound to carry the event uid and corresponding datum id.