### PR TITLE
Expose timestamps, configuration, and configuration timestamps in v2.

### DIFF
--- a/databroker/core.py
+++ b/databroker/core.py
@@ -1172,6 +1172,11 @@ class BlueskyEventStream(DataSourceMixin):
     exclude : list, optional
         Fields ('data keys') to exclude. By default none are excluded. This
         parameter is mutually exclusive with ``include``.
+    sub_dict : {"data", "timestamps"}, optional
+        Which sub-dict in the EventPage to use
+    configuration_for : str
+        The name of an object (e.g. device) whose configuration we want to
+        read.
     **kwargs :
         Additional keyword arguments are passed through to the base class.
     """

--- a/databroker/core.py
+++ b/databroker/core.py
@@ -27,7 +27,7 @@ import xarray
 from .intake_xarray_core.base import DataSourceMixin
 from .intake_xarray_core.xarray_container import RemoteXarray
 from .utils import LazyMap
-from bluesky_live.bluesky_run import documents_to_xarray, documents_to_xarray_config
+from bluesky_live.conversion import documents_to_xarray, documents_to_xarray_config
 from collections import deque, OrderedDict
 from dask.base import normalize_token
 

--- a/databroker/core.py
+++ b/databroker/core.py
@@ -27,6 +27,7 @@ import xarray
 from .intake_xarray_core.base import DataSourceMixin
 from .intake_xarray_core.xarray_container import RemoteXarray
 from .utils import LazyMap
+from bluesky_live.bluesky_run import documents_to_xarray, documents_to_xarray_config
 from collections import deque, OrderedDict
 from dask.base import normalize_token
 
@@ -606,171 +607,6 @@ def _fill(filler,
             get_datum_pages,
             last_datum_id=datum_id,
         )
-
-
-def _documents_to_xarray(*, start_doc, stop_doc, descriptor_docs,
-                         get_event_pages, filler, get_resource,
-                         lookup_resource_for_datum, get_datum_pages,
-                         include=None, exclude=None):
-    """
-    Represent the data in one Event stream as an xarray.
-
-    Parameters
-    ----------
-    start_doc: dict
-        RunStart Document
-    stop_doc : dict
-        RunStop Document
-    descriptor_docs : list
-        EventDescriptor Documents
-    filler : event_model.Filler
-    get_resource : callable
-        Expected signature ``get_resource(resource_uid) -> Resource``
-    lookup_resource_for_datum : callable
-        Expected signature ``lookup_resource_for_datum(datum_id) -> resource_uid``
-    get_datum_pages : callable
-        Expected signature ``get_datum_pages(resource_uid) -> generator``
-        where ``generator`` yields datum_page documents
-    get_event_pages : callable
-        Expected signature ``get_event_pages(descriptor_uid) -> generator``
-        where ``generator`` yields event_page documents
-    include : list, optional
-        Fields ('data keys') to include. By default all are included. This
-        parameter is mutually exclusive with ``exclude``.
-    exclude : list, optional
-        Fields ('data keys') to exclude. By default none are excluded. This
-        parameter is mutually exclusive with ``include``.
-
-    Returns
-    -------
-    dataset : xarray.Dataset
-    """
-    if include is None:
-        include = []
-    if exclude is None:
-        exclude = []
-    if include and exclude:
-        raise ValueError(
-            "The parameters `include` and `exclude` are mutually exclusive.")
-    # Data keys must not change within one stream, so we can safely sample
-    # just the first Event Descriptor.
-    if descriptor_docs:
-        data_keys = descriptor_docs[0]['data_keys']
-        if include:
-            keys = list(set(data_keys) & set(include))
-        elif exclude:
-            keys = list(set(data_keys) - set(exclude))
-        else:
-            keys = list(data_keys)
-
-    # Collect a Dataset for each descriptor. Merge at the end.
-    datasets = []
-    dim_counter = itertools.count()
-    event_dim_labels = {}
-    config_dim_labels = {}
-    for descriptor in descriptor_docs:
-        events = list(_flatten_event_page_gen(get_event_pages(descriptor['uid'])))
-        if not events:
-            continue
-        if any(data_keys[key].get('external') for key in keys):
-            filler('descriptor', descriptor)
-            filled_events = []
-            for event in events:
-                filled_event = _fill(
-                    filler, event, lookup_resource_for_datum, get_resource,
-                    get_datum_pages)
-                filled_events.append(filled_event)
-        else:
-            filled_events = events
-        times = [ev['time'] for ev in events]
-        seq_nums = [ev['seq_num'] for ev in events]
-        uids = [ev['uid'] for ev in events]
-        data_table = _transpose(filled_events, keys, 'data')
-        # external_keys = [k for k in data_keys if 'external' in data_keys[k]]
-
-        # Collect a DataArray for each field in Event, each field in
-        # configuration, and 'seq_num'. The Event 'time' will be the
-        # default coordinate.
-        data_arrays = {}
-
-        # Make DataArrays for Event data.
-        for key in keys:
-            field_metadata = data_keys[key]
-            # if the EventDescriptor doesn't provide names for the
-            # dimensions (it's optional) use the same default dimension
-            # names that xarray would.
-            try:
-                dims = tuple(field_metadata['dims'])
-            except KeyError:
-                ndim = len(field_metadata['shape'])
-                # Reuse dim labels.
-                try:
-                    dims = event_dim_labels[key]
-                except KeyError:
-                    dims = tuple(f'dim_{next(dim_counter)}' for _ in range(ndim))
-                    event_dim_labels[key] = dims
-            data_arrays[key] = xarray.DataArray(
-                data=data_table[key],
-                dims=('time',) + dims,
-                coords={'time': times},
-                name=key)
-
-        # Make DataArrays for configuration data.
-        for object_name, config in descriptor.get('configuration', {}).items():
-            data_keys = config['data_keys']
-            # For configuration, label the dimension specially to
-            # avoid key collisions.
-            scoped_data_keys = {key: f'{object_name}:{key}'
-                                for key in data_keys}
-            if include:
-                keys = {k: v for k, v in scoped_data_keys.items()
-                        if v in include}
-            elif exclude:
-                keys = {k: v for k, v in scoped_data_keys.items()
-                        if v not in include}
-            else:
-                keys = scoped_data_keys
-            for key, scoped_key in keys.items():
-                field_metadata = data_keys[key]
-                ndim = len(field_metadata['shape'])
-                # if the EventDescriptor doesn't provide names for the
-                # dimensions (it's optional) use the same default dimension
-                # names that xarray would.
-                try:
-                    dims = tuple(field_metadata['dims'])
-                except KeyError:
-                    try:
-                        dims = config_dim_labels[key]
-                    except KeyError:
-                        dims = tuple(f'dim_{next(dim_counter)}' for _ in range(ndim))
-                        config_dim_labels[key] = dims
-                data_arrays[scoped_key] = xarray.DataArray(
-                    # TODO Once we know we have one Event Descriptor
-                    # per stream we can be more efficient about this.
-                    data=numpy.tile(config['data'][key],
-                                    (len(times),) + ndim * (1,) or 1),
-                    dims=('time',) + dims,
-                    coords={'time': times},
-                    name=key)
-
-        # Finally, make DataArrays for 'seq_num' and 'uid'.
-        data_arrays['seq_num'] = xarray.DataArray(
-            data=seq_nums,
-            dims=('time',),
-            coords={'time': times},
-            name='seq_num')
-        data_arrays['uid'] = xarray.DataArray(
-            data=uids,
-            dims=('time',),
-            coords={'time': times},
-            name='uid')
-
-        datasets.append(xarray.Dataset(data_vars=data_arrays))
-    # Merge Datasets from all Event Descriptors into one representing the
-    # whole stream. (In the future we may simplify to one Event Descriptor
-    # per stream, but as of this writing we must account for the
-    # possibility of multiple.)
-    return xarray.merge(datasets)
 
 
 def _canonical(*, start, stop, entries, fill, strict_order=True):
@@ -1387,6 +1223,8 @@ class BlueskyEventStream(DataSourceMixin):
                  entry,
                  include=None,
                  exclude=None,
+                 sub_dict="data",
+                 configuration_for=None,
                  **kwargs):
 
         self._stream_name = stream_name
@@ -1404,7 +1242,16 @@ class BlueskyEventStream(DataSourceMixin):
         self._ds = None  # set by _open_dataset below
         self.include = include
         self.exclude = exclude
+        if sub_dict not in {"data", "timestamps"}:
+            raise ValueError(
+                "The parameter 'sub_dict' controls where the xarray should "
+                "contain the Events' 'data' (common case) or reading-specific "
+                "'timestamps' (sometimes needed for hardware debugging). It "
+                f"must be one of those two strings, not {sub_dict}.")
+        self._configuration_for = configuration_for
+        self._sub_dict = sub_dict
         self._partitions = None
+        self.__entry = entry
 
         super().__init__(metadata=metadata, **kwargs)
         # turn off any attempts at persistence
@@ -1455,17 +1302,33 @@ class BlueskyEventStream(DataSourceMixin):
 
     def _open_dataset(self):
         self._load_header()
-        self._ds = _documents_to_xarray(
-            start_doc=self._run_start_doc,
-            stop_doc=self._run_stop_doc,
-            descriptor_docs=self._descriptors,
-            get_event_pages=self._get_event_pages,
-            filler=self.fillers['delayed'],
-            get_resource=self._get_resource,
-            lookup_resource_for_datum=self._lookup_resource_for_datum,
-            get_datum_pages=self._get_datum_pages,
-            include=self.include,
-            exclude=self.exclude)
+        if self._configuration_for is not None:
+            self._ds = documents_to_xarray_config(
+                object_name=self._configuration_for,
+                sub_dict=self._sub_dict,
+                start_doc=self._run_start_doc,
+                stop_doc=self._run_stop_doc,
+                descriptor_docs=self._descriptors,
+                get_event_pages=self._get_event_pages,
+                filler=self.fillers['delayed'],
+                get_resource=self._get_resource,
+                lookup_resource_for_datum=self._lookup_resource_for_datum,
+                get_datum_pages=self._get_datum_pages,
+                include=self.include,
+                exclude=self.exclude)
+        else:
+            self._ds = documents_to_xarray(
+                sub_dict=self._sub_dict,
+                start_doc=self._run_start_doc,
+                stop_doc=self._run_stop_doc,
+                descriptor_docs=self._descriptors,
+                get_event_pages=self._get_event_pages,
+                filler=self.fillers['delayed'],
+                get_resource=self._get_resource,
+                lookup_resource_for_datum=self._lookup_resource_for_datum,
+                get_datum_pages=self._get_datum_pages,
+                include=self.include,
+                exclude=self.exclude)
 
     def read(self):
         """
@@ -1566,6 +1429,41 @@ class BlueskyEventStream(DataSourceMixin):
             self.url, self.http_args,
             self._source_id, self.container,
             partition)
+
+    @property
+    def config(self):
+        objects = set()
+        for d in self._descriptors:
+            objects.update(set(d["object_keys"]))
+        return intake.catalog.Catalog.from_dict(
+            {object_name: self.configure_new(configuration_for=object_name)
+             for object_name in objects}
+        )
+
+    @property
+    def config_timestamps(self):
+        objects = set()
+        for d in self._descriptors:
+            objects.update(set(d["object_keys"]))
+        return intake.catalog.Catalog.from_dict(
+            {object_name: self.configure_new(configuration_for=object_name,
+                                             sub_dict="timestamps")
+             for object_name in objects}
+        )
+
+    @property
+    def timestamps(self):
+        return self.configure_new(sub_dict="timestamps")
+
+    def configure_new(self, **kwargs):
+        """
+        Return self or, if args are provided, some new instance of type(self).
+
+        This is here so that the user does not have to remember whether a given
+        variable is a BlueskyRun or an *Entry* with a Bluesky Run. In either
+        case, ``obj()`` will return a BlueskyRun.
+        """
+        return self.__entry.get(**kwargs)
 
 
 class RemoteBlueskyEventStream(RemoteXarray):

--- a/databroker/tests/test_v2/generic.py
+++ b/databroker/tests/test_v2/generic.py
@@ -279,10 +279,8 @@ def test_include_and_exclude(bundle):
     assert 'motor' in entry().read().variables
     assert 'motor' not in entry(exclude=['motor']).read().variables
     assert 'motor' in entry(exclude=['NONEXISTENT']).read().variables
-    expected = set(['time', 'uid', 'seq_num', 'motor'])
+    expected = set(['time', 'motor'])
     assert set(entry(include=['motor']).read().variables) == expected
-    expected = set(['time', 'uid', 'seq_num', 'motor:motor_velocity'])
-    assert set(entry(include=['motor:motor_velocity']).read().variables) == expected
 
 
 def test_transforms(bundle):

--- a/databroker/tests/test_v2/test_core.py
+++ b/databroker/tests/test_v2/test_core.py
@@ -3,7 +3,7 @@ import os
 import tempfile
 import xarray
 from ... import core
-from ...core import documents_to_xarray
+from bluesky_live.conversion import documents_to_xarray
 
 
 def no_event_pages(descriptor_uid):

--- a/databroker/tests/test_v2/test_core.py
+++ b/databroker/tests/test_v2/test_core.py
@@ -3,7 +3,7 @@ import os
 import tempfile
 import xarray
 from ... import core
-from ...core import _documents_to_xarray
+from ...core import documents_to_xarray
 
 
 def no_event_pages(descriptor_uid):
@@ -28,7 +28,7 @@ def test_no_descriptors():
     run_bundle = event_model.compose_run()
     start_doc = run_bundle.start_doc
     stop_doc = run_bundle.compose_stop()
-    _documents_to_xarray(
+    documents_to_xarray(
         start_doc=start_doc,
         stop_doc=stop_doc,
         descriptor_docs=[],
@@ -47,7 +47,7 @@ def test_no_events():
         name='primary')
     descriptor_doc = desc_bundle.descriptor_doc
     stop_doc = run_bundle.compose_stop()
-    _documents_to_xarray(
+    documents_to_xarray(
         start_doc=start_doc,
         stop_doc=stop_doc,
         descriptor_docs=[descriptor_doc],

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
+bluesky-live
 boltons
 cachetools
 dask[array,bag]


### PR DESCRIPTION
Recall that devices implement `read()` and `read_configuration()`. Respectively, these produce readings that go into Events and configurational readings that go into Event Descriptors. Each of these readings include both values and associated hardware timestamps.

```py
In [1]: from ophyd import Device, Component

In [2]: from ophyd.sim import Signal, SynSignal

In [3]: import random

In [4]: class Thing(Device):
   ...:     intensity = Component(SynSignal, func=random.random)
   ...:     exposure_time = Component(Signal, value=1, kind='config')
   ...: 

In [5]: thing = Thing(name='thing')

In [6]: thing.read()  # These will go into the Event.
Out[6]: 
OrderedDict([('thing_intensity',
              {'value': 0.008608399314166015, 'timestamp': 1603384540.002283})])

In [7]: thing.read_configuration()  # These will go into the Event Descriptor.
Out[7]: 
OrderedDict([('thing_exposure_time',
              {'value': 1, 'timestamp': 1603384540.0025058})])
```

Let's take data with this and then access it with the v2 API. (Off-screen we created `RE` and hooked it up to a `serializer` connected to Mongo, with a corresponding `catalog`.) 

```py
In [7]: RE(count([thing], 10), serializer)
Out[7]: ('102541b3-bc23-42b8-83d6-a9994178edf5',)

In [8]: run = catalog[-1]

In [11]: run
Out[11]: 
BlueskyRun
  uid='102541b3-bc23-42b8-83d6-a9994178edf5'
  exit_status='success'
  2020-10-22 12:37:20.926 -- 2020-10-22 12:37:21.013
  Streams:
    * primary

In [12]: run.primary
Out[12]: <BlueskyEventStream 'primary' from Run 102541b3...>

In [13]: run.primary.read()
Out[13]: 
<xarray.Dataset>
Dimensions:                    (time: 10)
Coordinates:
  * time                       (time) float64 1.603e+09 1.603e+09 ... 1.603e+09
Data variables:
    thing_intensity            (time) float64 0.3347 0.3347 ... 0.3347 0.3347
    thing:thing_exposure_time  (time) int64 1 1 1 1 1 1 1 1 1 1
    seq_num                    (time) int64 1 2 3 4 5 6 7 8 9 10
    uid                        (time) <U36 '47f9c410-1c0f-478e-be40-550ccb63a...
```

This gives us the values from the Events and the configuration values from the Event Descriptor. It automatically numpy-broadcasts the configuration values so that it is easy to do column arithmetic, such as dividing intensity by exposure. This result also includes the special columns `seq_num` and `uid`, which are also from the Events.

There are major usability problems and technical with this:

* The mixture of Event-wise readings and configuration is potentially confusing, and the mapping between which configuration belongs to which columns is not machine-readable nor necessarily human-readable.
* In real use cases, it quickly becomes very long because some devices record a lot of configuration.
* There is no way to access the hardware timestamps from this API. These are rarely useful for analysis -- more for hardware debugging -- but they should still be accessible.
* There is a potential for name collisions!

The structure of this output was posed early in the development of v2, and it needs to be revisited to address these issues. Because v2 is marked as "experimental" we can make the necessary changes in a minor release, e.g. databroker v1.2.0. This PR:

* Slims down the output of `run.<stream name>.read()` to return only the data from `Event['data']` with no possibility of name collisions. (This is a backward-incompatible change because it removes columns.)
* Adds the accessors `run.<stream name>.config.<object name>`, `run.<stream name>.timestamps`, and `run.<stream name>.config_timestamps.<object name>` to access these other values from the documents.
* Uses xarray's `attrs` dict to provide a machine- and human-readable mapping between each column in the output of `run.<stream name>.read()` and the associated table of configuration readings. For example, if you have multiple detectors, you can take which intensities go with which exposure times.

```py
In [12]: run.primary.read()  # Same usage as above, but a leaner result
Out[12]: 
<xarray.Dataset>
Dimensions:          (time: 10)
Coordinates:
  * time             (time) float64 1.603e+09 1.603e+09 ... 1.603e+09 1.603e+09
Data variables:
    thing_intensity  (time) float64 0.1325 0.1325 0.1325 ... 0.1325 0.1325

In [13]: run.primary().read()['thing_intensity']  # Each column (DataArray) has "Attributes" showing the object (i.e. device) it came from
Out[13]: 
<xarray.DataArray 'thing_intensity' (time: 10)>
array([0.13245665, 0.13245665, 0.13245665, 0.13245665, 0.13245665,
       0.13245665, 0.13245665, 0.13245665, 0.13245665, 0.13245665])
Coordinates:
  * time     (time) float64 1.603e+09 1.603e+09 ... 1.603e+09 1.603e+09
Attributes:
    object:   thing

In [14]: list(run.primary.config)  # one entry for each of EventDescriptor['object_keys'], i.e. ophyd device names
Out[14]: ['thing']

In [15]: run.primary.config.thing.read()  # from EventDescriptor['configuration']['thing']['data']
Out[15]: 
<xarray.Dataset>
Dimensions:              (time: 10)
Coordinates:
  * time                 (time) float64 1.603e+09 1.603e+09 ... 1.603e+09
Data variables:
    thing_exposure_time  (time) int64 1 1 1 1 1 1 1 1 1 1

In [16]: run.primary.config_timestamps.thing.read()  # from EventDescriptor['configuration']['thing']['timestamps']
Out[16]: 
<xarray.Dataset>
Dimensions:              (time: 10)
Coordinates:
  * time                 (time) float64 1.603e+09 1.603e+09 ... 1.603e+09
Data variables:
    thing_exposure_time  (time) float64 1.603e+09 1.603e+09 ... 1.603e+09

In [17]: run.primary.timestamps.read()  # from Event['timestamps']
Out[17]: 
<xarray.Dataset>
Dimensions:          (time: 10)
Coordinates:
  * time             (time) float64 1.603e+09 1.603e+09 ... 1.603e+09 1.603e+09
Data variables:
    thing_intensity  (time) float64 1.603e+09 1.603e+09 ... 1.603e+09 1.603e+09
```

Needs more unit tests