### PR TITLE
MNT: Adjust to changes in intake

### DIFF
--- a/databroker/core.py
+++ b/databroker/core.py
@@ -30,6 +30,10 @@ from .utils import LazyMap
 from collections import deque, OrderedDict
 from dask.base import normalize_token
 
+try:
+    from intake.catalog.remote import RemoteCatalog as intake_RemoteCatalog
+except ImportError:
+    from intake.catalog.base import RemoteCatalog as intake_RemoteCatalog
 
 logger = logging.getLogger(__name__)
 
@@ -836,7 +840,7 @@ def _canonical(*, start, stop, entries, fill, strict_order=True):
         yield ('stop', stop)
 
 
-class RemoteBlueskyRun(intake.catalog.base.RemoteCatalog):
+class RemoteBlueskyRun(intake_RemoteCatalog):
     """
     Catalog representing one Run.
 

--- a/databroker/core.py
+++ b/databroker/core.py
@@ -1032,6 +1032,10 @@ class BlueskyRun(intake.catalog.Catalog):
         Additional keyword arguments are passed through to the base class,
         Catalog.
     """
+    # Work around
+    # https://github.com/intake/intake/issues/545
+    _container = None
+
     # opt-out of the persistence features of intake
     @property
     def has_been_persisted(self):

--- a/databroker/discovery.py
+++ b/databroker/discovery.py
@@ -10,6 +10,10 @@ class EntrypointEntry(CatalogEntry):
     """
     A catalog entry for an entrypoint.
     """
+    # Work around
+    # https://github.com/intake/intake/issues/545
+    _container = None
+
     def __init__(self, entrypoint):
         self._entrypoint = entrypoint
 
@@ -37,6 +41,9 @@ class EntrypointsCatalog(Catalog):
     """
     A catalog of discovered entrypoint catalogs.
     """
+    # Work around
+    # https://github.com/intake/intake/issues/545
+    _container = None
 
     def __init__(self, *args, entrypoints_group='intake.catalogs', paths=None,
                  **kwargs):
@@ -58,6 +65,9 @@ class EntrypointsCatalog(Catalog):
 
 
 class V0Entry(CatalogEntry):
+    # Work around
+    # https://github.com/intake/intake/issues/545
+    _container = None
 
     def __init__(self, name, *args, **kwargs):
         self._name = name
@@ -84,6 +94,10 @@ class V0Catalog(Catalog):
     """
     Build v2.Brokers based on any v0-style configs we can find.
     """
+    # Work around
+    # https://github.com/intake/intake/issues/545
+    _container = None
+
     def __init__(self, *args, paths=CONFIG_SEARCH_PATH, **kwargs):
         self._paths = paths
         super().__init__(*args, **kwargs)
@@ -97,6 +111,10 @@ class MergedCatalog(Catalog):
     """
     A Catalog that merges the entries of a list of catalogs.
     """
+    # Work around
+    # https://github.com/intake/intake/issues/545
+    _container = None
+
     def __init__(self, catalogs, *args, **kwargs):
         self._catalogs = catalogs
         super().__init__(*args, **kwargs)

--- a/databroker/tests/utils.py
+++ b/databroker/tests/utils.py
@@ -36,14 +36,11 @@ def build_intake_jsonl_backed_broker(request):
 
 
 def build_intake_mongo_backed_broker(request):
-    mongobox = pytest.importorskip('mongobox')
-    box = mongobox.MongoBox()
-    box.start()
-    client = box.client()
+    mongomock = pytest.importorskip('mongomock')
+    client = mongomock.MongoClient()
 
     def teardown():
-        "Delete temporary MongoDB data directory."
-        box.stop()
+        client.close()
 
     request.addfinalizer(teardown)
     broker = mongo_normalized.BlueskyMongoCatalog(
@@ -55,13 +52,11 @@ def build_intake_mongo_backed_broker(request):
 
 
 def build_intake_mongo_embedded_backed_broker(request):
-    mongobox = pytest.importorskip('mongobox')
+    mongomock = pytest.importorskip('mongomock')
+    client = mongomock.MongoClient()
     tmp_dir = tempfile.TemporaryDirectory()
     tmp_path = tmp_dir.name
     catalog_path = Path(tmp_path) / 'catalog.yml'
-    box = mongobox.MongoBox()
-    box.start()
-    client = box.client()
     with open(catalog_path, 'w') as file:
         file.write(f"""
 sources:
@@ -79,7 +74,7 @@ sources:
 
     def teardown():
         "Delete temporary MongoDB data directory."
-        box.stop()
+        client.close()
         tmp_dir.cleanup()
 
     request.addfinalizer(teardown)

--- a/databroker/v2.py
+++ b/databroker/v2.py
@@ -63,6 +63,9 @@ class Broker(Catalog):
     def __init__(self, *, handler_registry=None, root_map=None,
                  filler_class=event_model.Filler, transforms=None, **kwargs):
 
+        # Work around https://github.com/intake/intake/issues/543
+        self.auth = kwargs.pop("auth", None)
+
         if isinstance(filler_class, str):
             module_name, _, class_name = filler_class.rpartition('.')
             self._filler_class = getattr(importlib.import_module(module_name), class_name)

--- a/databroker/v2.py
+++ b/databroker/v2.py
@@ -59,6 +59,9 @@ class Broker(Catalog):
         Additional keyword arguments are passed through to the base class,
         Catalog.
     """
+    # Work around
+    # https://github.com/intake/intake/issues/545
+    _container = None
 
     def __init__(self, *, handler_registry=None, root_map=None,
                  filler_class=event_model.Filler, transforms=None, **kwargs):

--- a/doc/source/v2/user/index.rst
+++ b/doc/source/v2/user/index.rst
@@ -36,6 +36,8 @@ User Documentation
    serializer.close()
    from intake.catalog.local import YAMLFileCatalog
    csx = YAMLFileCatalog('source/_catalogs/csx.yml')
+   # Work around intake#545.
+   csx._container = None
    import databroker
    # Monkey-patch to override databroker.catalog so we can directly
    # add examples instead of taking the trouble to create and then clean up

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -6,7 +6,7 @@ flake8
 glueviz
 intake[server]
 matplotlib
-mongobox
+mongomock
 numpy >=1.16.0  # for astropy (via glueviz)
 ophyd
 pathlib


### PR DESCRIPTION
This is the location of `RemoteCatalog` on the default branch of intake, I suspect it is better to shim it here and make sure the deprecation is noted in intake.