### PR TITLE
Rename 'canonical' to 'documents'.

### DIFF
--- a/databroker/core.py
+++ b/databroker/core.py
@@ -609,7 +609,7 @@ def _fill(filler,
         )
 
 
-def _canonical(*, start, stop, entries, fill, strict_order=True):
+def _documents(*, start, stop, entries, fill, strict_order=True):
     """
     Yields documents from this Run in chronological order.
 
@@ -781,7 +781,7 @@ class RemoteBlueskyRun(intake_RemoteCatalog):
     def _close(self):
         self.bag = None
 
-    def canonical(self, *, fill, strict_order=True):
+    def documents(self, *, fill, strict_order=True):
         # Special case for 'delayed' since it *is* supported in the local mode
         # of usage.
         if fill == 'delayed':
@@ -789,7 +789,7 @@ class RemoteBlueskyRun(intake_RemoteCatalog):
                 "Delayed access is not yet supported via the client--server "
                 "usage.")
 
-        yield from _canonical(start=self.metadata['start'],
+        yield from _documents(start=self.metadata['start'],
                               stop=self.metadata['stop'],
                               entries=self._entries,
                               fill=fill,
@@ -797,9 +797,15 @@ class RemoteBlueskyRun(intake_RemoteCatalog):
 
     def read_canonical(self):
         warnings.warn(
-            "The method read_canonical has been renamed canonical. This alias "
+            "The method read_canonical has been renamed documents. This alias "
             "may be removed in a future release.")
-        yield from self.canonical(fill='yes')
+        yield from self.documents(fill='yes')
+
+    def canonical(self):
+        warnings.warn(
+            "The method canonical has been renamed documents. This alias "
+            "may be removed in a future release.")
+        yield from self.documents(fill='yes')
 
     def __repr__(self):
         try:
@@ -1080,8 +1086,8 @@ class BlueskyRun(intake.catalog.Catalog):
 
     get = __call__ = configure_new
 
-    def canonical(self, *, fill, strict_order=True):
-        yield from _canonical(start=self.metadata['start'],
+    def documents(self, *, fill, strict_order=True):
+        yield from _documents(start=self.metadata['start'],
                               stop=self.metadata['stop'],
                               entries=self._entries,
                               fill=fill,
@@ -1089,9 +1095,15 @@ class BlueskyRun(intake.catalog.Catalog):
 
     def read_canonical(self):
         warnings.warn(
-            "The method read_canonical has been renamed canonical. This alias "
+            "The method read_canonical has been renamed documents. This alias "
             "may be removed in a future release.")
-        yield from self.canonical(fill='yes')
+        yield from self.documents(fill='yes')
+
+    def canonical(self):
+        warnings.warn(
+            "The method canonical has been renamed documents. This alias "
+            "may be removed in a future release.")
+        yield from self.documents(fill='yes')
 
     def get_file_list(self, resource):
         """

--- a/databroker/v1.py
+++ b/databroker/v1.py
@@ -430,7 +430,7 @@ class Broker:
             get_documents_router = _GetDocumentsRouter(self.prepare_hook,
                                                        merge_config_into_event,
                                                        stream_name=stream_name)
-            for name, doc in self._catalog[uid].canonical(fill=_FILL[bool(fill)],
+            for name, doc in self._catalog[uid].documents(fill=_FILL[bool(fill)],
                                                           strict_order=True):
                 yield from get_documents_router(name, doc)
 
@@ -916,7 +916,7 @@ class Broker:
         file_pairs = []
 
         for header in headers:
-            for name, doc in self._catalog[header.start['uid']].canonical(fill='no'):
+            for name, doc in self._catalog[header.start['uid']].documents(fill='no'):
                 if name == 'event_page':
                     for event in event_model.unpack_event_page(doc):
                         db.insert('event', event)
@@ -948,7 +948,7 @@ class Broker:
         total_size = 0
         for header in headers:
             run = self._catalog[header.start['uid']]
-            for name, doc in self._catalog[header.start['uid']].canonical(fill='no'):
+            for name, doc in self._catalog[header.start['uid']].documents(fill='no'):
                 if name == 'resource':
                     for filepath in run.get_file_list(doc):
                         total_size += os.path.getsize(filepath)

--- a/doc/source/v2/developer/index.rst
+++ b/doc/source/v2/developer/index.rst
@@ -36,7 +36,7 @@ as a Catalog of Event Streams, :class:`BlueskyRun`. For example, the entries in
 a :class:`BlueskyRun` might have the names ``'primary'`` and ``'baseline'``.
 The entries always contain instances of :class:`BlueskyEventStream`.
 :class:`BlueskyRun` extends the standard Catalog interface with a special
-method :meth:BlueskyRun.canonical`. This returns a generator that yields
+method :meth:BlueskyRun.documents`. This returns a generator that yields
 ``(name, doc)`` pairs, recreating the stream of documents that would have been
 emitted during data acquisition. (This is akin to ``Header.documents()`` in
 DataBroker v0.x.)

--- a/doc/source/v2/user/index.rst
+++ b/doc/source/v2/user/index.rst
@@ -285,6 +285,11 @@ metadata. (See event-model_.) To access the run---effectively replaying the
 chronological stream of documents that were emitted during data
 acquisition---use the ``documents()`` method.
 
+.. versionchanged:: 1.2.0
+
+   The ``documents`` method was formerly named ``canonical``. The old name is
+   still supported but deprecated.
+
 .. ipython:: python
 
    run.documents(fill='yes')

--- a/doc/source/v2/user/index.rst
+++ b/doc/source/v2/user/index.rst
@@ -283,11 +283,11 @@ Replay Document Stream
 Bluesky is built around a streaming-friendly representation of data and
 metadata. (See event-model_.) To access the run---effectively replaying the
 chronological stream of documents that were emitted during data
-acquisition---use the ``canonical()`` method.
+acquisition---use the ``documents()`` method.
 
 .. ipython:: python
 
-   run.canonical(fill='yes')
+   run.documents(fill='yes')
 
 This generator yields ``(name, doc)`` pairs and can be fed into streaming
 visualization, processing, and serialization tools that consume this


### PR DESCRIPTION
The old method is still supported and issues a warning.

Closes #618. See that issue for context and motivation.