### PR TITLE
Revert workarounds to intake issues fixed upstream.

### DIFF
--- a/databroker/core.py
+++ b/databroker/core.py
@@ -874,10 +874,6 @@ class BlueskyRun(intake.catalog.Catalog):
         Additional keyword arguments are passed through to the base class,
         Catalog.
     """
-    # Work around
-    # https://github.com/intake/intake/issues/545
-    _container = None
-
     # opt-out of the persistence features of intake
     @property
     def has_been_persisted(self):

--- a/databroker/discovery.py
+++ b/databroker/discovery.py
@@ -10,10 +10,6 @@ class EntrypointEntry(CatalogEntry):
     """
     A catalog entry for an entrypoint.
     """
-    # Work around
-    # https://github.com/intake/intake/issues/545
-    _container = None
-
     def __init__(self, entrypoint):
         self._entrypoint = entrypoint
 
@@ -41,9 +37,6 @@ class EntrypointsCatalog(Catalog):
     """
     A catalog of discovered entrypoint catalogs.
     """
-    # Work around
-    # https://github.com/intake/intake/issues/545
-    _container = None
 
     def __init__(self, *args, entrypoints_group='intake.catalogs', paths=None,
                  **kwargs):
@@ -65,9 +58,6 @@ class EntrypointsCatalog(Catalog):
 
 
 class V0Entry(CatalogEntry):
-    # Work around
-    # https://github.com/intake/intake/issues/545
-    _container = None
 
     def __init__(self, name, *args, **kwargs):
         self._name = name
@@ -94,10 +84,6 @@ class V0Catalog(Catalog):
     """
     Build v2.Brokers based on any v0-style configs we can find.
     """
-    # Work around
-    # https://github.com/intake/intake/issues/545
-    _container = None
-
     def __init__(self, *args, paths=CONFIG_SEARCH_PATH, **kwargs):
         self._paths = paths
         super().__init__(*args, **kwargs)
@@ -111,10 +97,6 @@ class MergedCatalog(Catalog):
     """
     A Catalog that merges the entries of a list of catalogs.
     """
-    # Work around
-    # https://github.com/intake/intake/issues/545
-    _container = None
-
     def __init__(self, catalogs, *args, **kwargs):
         self._catalogs = catalogs
         super().__init__(*args, **kwargs)

--- a/databroker/v2.py
+++ b/databroker/v2.py
@@ -63,9 +63,6 @@ class Broker(Catalog):
     def __init__(self, *, handler_registry=None, root_map=None,
                  filler_class=event_model.Filler, transforms=None, **kwargs):
 
-        # Work around https://github.com/intake/intake/issues/543
-        self.auth = kwargs.pop("auth", None)
-
         if isinstance(filler_class, str):
             module_name, _, class_name = filler_class.rpartition('.')
             self._filler_class = getattr(importlib.import_module(module_name), class_name)

--- a/databroker/v2.py
+++ b/databroker/v2.py
@@ -59,9 +59,6 @@ class Broker(Catalog):
         Additional keyword arguments are passed through to the base class,
         Catalog.
     """
-    # Work around
-    # https://github.com/intake/intake/issues/545
-    _container = None
 
     def __init__(self, *, handler_registry=None, root_map=None,
                  filler_class=event_model.Filler, transforms=None, **kwargs):

--- a/doc/source/v2/user/index.rst
+++ b/doc/source/v2/user/index.rst
@@ -36,8 +36,6 @@ User Documentation
    serializer.close()
    from intake.catalog.local import YAMLFileCatalog
    csx = YAMLFileCatalog('source/_catalogs/csx.yml')
-   # Work around intake#545.
-   csx._container = None
    import databroker
    # Monkey-patch to override databroker.catalog so we can directly
    # add examples instead of taking the trouble to create and then clean up


### PR DESCRIPTION
Specifically, intake#543 and intake#545 were both addressed upstream. Because
these issues were fixed before they were released, there is no reason to
retain workarounds in databroker.