### PR TITLE
Summary projector

### DIFF
--- a/databroker/projector.py
+++ b/databroker/projector.py
@@ -208,7 +208,7 @@ class Projector():
                 if self._metadata_cb:
                     value = run.metadata['start'].get(projection_linked_field)
                     if value is None:
-                        self.issues.append(f"{run['start']['uid']} Start key misising in run {field_key}: {projection_linked_field}")
+                        self.issues.append(f"{run.metadata['start']['uid']} Start key misising in run {field_key}: {projection_linked_field}")
                         continue
                     self._metadata_cb(field_key, value)
                 continue
@@ -357,6 +357,14 @@ def project_xarray(run: BlueskyRun, *args, projection=None, projection_name=None
     dataset = xarray.Dataset(data_vars, attrs=attrs)
     return dataset, projector.issues
 
+# def project_xarray_single_stream(run: BlueskyRun, stream_name, projection=None, projection_name=None):
+#     stream_data = None
+#     issues = []
+#     try:
+#         stream_data = run[stream_name].to_dask()[projection_linked_field]
+#     except Exception as e:
+#         issues.append(f"Error projecting {run.metadata['start']['uid']} for stream {stream_name} ")
+#     return stream_data, issues
 
 def get_xarray_config_field(dataset: xarray.Dataset,
                             projection_field,

--- a/databroker/projector.py
+++ b/databroker/projector.py
@@ -225,8 +225,9 @@ class Projector():
                     try:
                         stream = run[projection_stream]
                     except KeyError:
-                        raise ProjectionError(f"Stream {projection_stream} specified does not exists {run.cat.name} {run.metadata['start']['uid']}")
-  
+                        raise ProjectionError(f"Stream {projection_stream} specified does" +
+                                              f"not exists {run.metadata['start']['uid']}")
+
                     value = stream.to_dask()[projection_linked_field]
                     self._event_field_cb(field_key,
                                          projection_stream,
@@ -248,7 +249,7 @@ class Projector():
                                                  projection_linked_field,
                                                  value)
             else:
-                raise KeyError(f'Unknown location: {projection_location} in projection.')
+                raise ProjectionError(f'Unknown location: {projection_location} in projection.')
 
 
 def  project_xarray(run: BlueskyRun, *args, projection=None, projection_name=None):

--- a/databroker/projector.py
+++ b/databroker/projector.py
@@ -238,6 +238,7 @@ class Projector():
                         #                       f"not exists {run.metadata['start']['uid']}")
                         self._issues.append(f"Stream {projection_stream} specified does" +
                                               f"not exists {run.metadata['start']['uid']}")
+                        continue
 
                     value = stream.to_dask()[projection_linked_field]
                     self._event_field_cb(field_key,
@@ -261,7 +262,7 @@ class Projector():
                                                  value)
             else:
                 # raise ProjectionError(f'Unknown location: {projection_location} in projection.')
-                f"Unknown location: {projection_location} in projection."
+                self._issues.append(f"Unknown location: {projection_location} in projection.")
 
 
 def project_xarray(run: BlueskyRun, *args, projection=None, projection_name=None):

--- a/databroker/projector.py
+++ b/databroker/projector.py
@@ -208,7 +208,11 @@ class Projector():
                 if self._metadata_cb:
                     value = run.metadata['start'].get(projection_linked_field)
                     if value is None:
-                        self.issues.append(f"{run.metadata['start']['uid']} Start key misising in run {field_key}: {projection_linked_field}")
+                        self.issues.append(
+                            (f"{run.metadata['start']['uid']} "
+                             f"Start key misising in run {field_key}: "
+                             f"{projection_linked_field}")
+                        )
                         continue
                     self._metadata_cb(field_key, value)
                 continue
@@ -237,7 +241,7 @@ class Projector():
                         # raise ProjectionError(f"Stream {projection_stream} specified does" +
                         #                       f"not exists {run.metadata['start']['uid']}")
                         self._issues.append(f"Stream {projection_stream} specified does" +
-                                              f"not exists {run.metadata['start']['uid']}")
+                                            f"not exists {run.metadata['start']['uid']}")
                         continue
 
                     value = stream.to_dask()[projection_linked_field]
@@ -366,6 +370,7 @@ def project_xarray(run: BlueskyRun, *args, projection=None, projection_name=None
 #         issues.append(f"Error projecting {run.metadata['start']['uid']} for stream {stream_name} ")
 #     return stream_data, issues
 
+
 def get_xarray_config_field(dataset: xarray.Dataset,
                             projection_field,
                             config_index,
@@ -407,7 +412,7 @@ def project_summary_dict(
     EXPERIMENTAL: projection code is experimental and could change in the near future.
 
     This is intended to be used by applications that need fast access to summary data. For example,
-    a small number of fields might be displayed for multiple runs in a list. 
+    a small number of fields might be displayed for multiple runs in a list.
     Projections come with multiple types: linked, and caclulated. Calculated fields are only supported
     in the data (not at the top-level attrs).
 

--- a/databroker/tests/test_projector.py
+++ b/databroker/tests/test_projector.py
@@ -105,6 +105,7 @@ class MockRun():
     def __init__(self, projections=[], sample='',):
         self.metadata = {
             'start': {
+                'uid': 42,
                 'sample': sample,
                 'projections': projections
             },

--- a/databroker/tests/test_projector.py
+++ b/databroker/tests/test_projector.py
@@ -1,12 +1,21 @@
 import pytest
+
 import xarray
+
 from databroker.core import BlueskyRun
 
-from ..projector import get_run_projection, project_xarray, ProjectionError, get_xarray_config_field
+from ..projector import (
+    get_run_projection,
+    project_xarray,
+    ProjectionError,
+    get_xarray_config_field,
+    project_summary_dict
+)
 
 EVENT_FIELD = 'event_field_name'
 EVENT_CONFIGURATION_FIELD = 'event_configuration_name'
 START_DOC_FIELD = 'start_doc_metadata_name'
+START_DOC_FIELD_2 = 'start_doc_metadata_name_2'
 MOCK_IMAGE = xarray.DataArray([[1, 2], [3, 4]])
 BEAMLINE_ENERGY_VALS = [1, 2, 3, 4, 5]
 OTHER_VALS = [-1, -2, -3, -4, -5]
@@ -18,6 +27,7 @@ good_projection = [{
         "configuration": {"name": "RSoXS"},
         "projection": {
             START_DOC_FIELD: {"type": "linked", "location": "start", "field": "sample"},
+            START_DOC_FIELD_2: {"type": "linked", "location": "start", "field": "sample"},
             EVENT_FIELD: {"type": "linked", "location": "event", "stream": "primary", "field": "ccd"},
             EVENT_CONFIGURATION_FIELD: {"type": "linked",
                                         "location": "configuration",
@@ -68,6 +78,7 @@ projections_same_name = [
          "name": "nxsas"
         }
     ]
+
 
 
 class MockStream():
@@ -170,7 +181,7 @@ def test_nonexistent_stream():
         project_xarray(mock_run)
 
 
-def test_projector():
+def test_xarray_projector():
     mock_run = make_mock_run(good_projection, 'one_ring')
     dataset = project_xarray(mock_run)
     # Ensure that the to_dask function was called on both
@@ -181,3 +192,24 @@ def test_projector():
     for idx, image in enumerate(dataset[EVENT_FIELD]):
         comparison = image == mock_run['primary'].dataset['ccd'][idx]  # xarray of comparison results
         assert comparison.all()  # False if comparision does not contain all True
+
+
+def test_summary_projector():
+    mock_run = make_mock_run(good_projection, 'one_ring')
+    dataset = project_summary_dict(mock_run)
+    projection_fields = []
+    for field, value in good_projection[0]['projection'].items():
+        if 'location' in value and value['location'] == 'start':
+            projection_fields.append(field)
+             
+    assert len(dataset) > 0
+    for field in projection_fields:
+        assert dataset[START_DOC_FIELD] == 'one_ring'
+        assert dataset[START_DOC_FIELD_2] == 'one_ring'
+
+
+def test_summary_projector_filtered():
+    mock_run = make_mock_run(good_projection, 'one_ring')
+    dataset = project_summary_dict(mock_run, return_fields=[START_DOC_FIELD_2])
+    assert len(dataset) == 1
+    assert dataset[START_DOC_FIELD_2] == 'one_ring'


### PR DESCRIPTION
This PR primarily creates a simplified projector. Before this, the only projector available was the project_xarray function which is comprehensive and builds up an xarray.Dataset with data from the full run.

That is pretty heavy weight, and potentially overkill for applications when want two things:

- a quick summary of a few metadata fields when presenting a list of runs
- projected fields

So, this uses the same rules for selecting a projection that the xarray projector uses, but only projects metadata from the start document. It also has a parameter that allows callers to send a list of just a few fields that they want. I had support of GraphQL in mind there.

Maybe we want to add stop document info too? A summary might want to know whether runs completed and how many events they have.