### PR TITLE
Fix back-compat shim.

### DIFF
--- a/databroker/core.py
+++ b/databroker/core.py
@@ -801,11 +801,11 @@ class RemoteBlueskyRun(intake_RemoteCatalog):
             "may be removed in a future release.")
         yield from self.documents(fill='yes')
 
-    def canonical(self):
+    def canonical(self, *, fill, strict_order=True):
         warnings.warn(
             "The method canonical has been renamed documents. This alias "
             "may be removed in a future release.")
-        yield from self.documents(fill='yes')
+        yield from self.documents(fill=fill, strict_order=strict_order)
 
     def __repr__(self):
         try:
@@ -1099,11 +1099,11 @@ class BlueskyRun(intake.catalog.Catalog):
             "may be removed in a future release.")
         yield from self.documents(fill='yes')
 
-    def canonical(self):
+    def canonical(self, *, fill, strict_order=True):
         warnings.warn(
             "The method canonical has been renamed documents. This alias "
             "may be removed in a future release.")
-        yield from self.documents(fill='yes')
+        yield from self.documents(fill=fill, strict_order=strict_order)
 
     def get_file_list(self, resource):
         """

--- a/databroker/tests/test_v2/generic.py
+++ b/databroker/tests/test_v2/generic.py
@@ -214,7 +214,7 @@ def test_canonical(bundle):
 
     # Smoke test for back-compat alias
     with pytest.warns(UserWarning):
-        next(run.canonical())
+        next(run.canonical(fill="yes"))
 
     compare(run.documents(fill='yes'),
             (filler(name, doc) for name, doc in bundle.docs))


### PR DESCRIPTION
In #623 we renamed `canonical` to `documents` and made a back-compatible shim for `canonical`. I gave it the wrong signature and also called it with that (wrong) signature in the tests. Fixed to have the proper signature.