### PR TITLE
Remove index creation.

### DIFF
--- a/databroker/assets/mongo.py
+++ b/databroker/assets/mongo.py
@@ -46,28 +46,11 @@ class RegistryRO(BaseRegistryRO):
         self.__datum_col = None
         self.__res_col = None
         self.__res_update_col = None
-        self._resource_index = False
-        self._datum_index = False
 
     def disconnect(self):
         self.__db = None
         self.__datum_col = None
         self.__res_col = None
-
-    def _create_resource_index(self):
-        if not self._resource_index:
-            self._resource_col.create_index('resource_id')
-            self._resource_update_col.create_index([
-                ('resource', pymongo.DESCENDING),
-                ('time', pymongo.DESCENDING)
-            ])
-            self._resource_index = True
-
-    def _create_datum_index(self):
-        if not self._datum_index:
-            self._datum_col.create_index('datum_id', unique=True)
-            self._datum_col.create_index('resource')
-            self._datum_index = True
 
     @property
     def _db(self):
@@ -118,39 +101,31 @@ class RegistryRO(BaseRegistryRO):
 
 class Registry(RegistryRO, RegistryTemplate):
     """Registry object that knows how to create new documents.
-       Overriding base class methods to make index creation more lazy.
-       This allows databroker to work with a read only mongo account.
     """
     def insert_datum(self, resource, datum_id, datum_kwargs,
                      ignore_duplicate_error=False):
-        self._create_datum_index()
         return super().insert_datum(resource, datum_id, datum_kwargs,
                                     ignore_duplicate_error=ignore_duplicate_error)
 
     def bulk_insert_datum(self, resource, datum_ids, datum_kwarg_list):
-        self._create_datum_index()
         return super().bulk_insert_datum(resource, datum_ids, datum_kwarg_list)
 
     def bulk_register_datum_table(self, resource_uid, dkwargs_table,
                                   validate=False):
-        self._create_datum_index()
         return super().bulk_register_datum_table(resource_uid, dkwargs_table,
                                                  validate=validate)
 
     def bulk_register_datum_list(self, resource_uid, dkwargs_list,
                                  validate=False):
-        self._create_datum_index()
         return super().bulk_register_datum_list(resource_uid, dkwargs_list,
                                                 validate=validate)
 
     def register_datum(self, resource_uid, datum_kwargs, validate=False):
-        self._create_datum_index()
         return super().register_datum(resource_uid, datum_kwargs,
                                       validate=validate)
 
     def register_resource(self, spec, root, rpath, rkwargs,
                           path_semantics='posix', run_start=None):
-        self._create_resource_index()
         return super().register_resource(spec, root, rpath, rkwargs,
                                          path_semantics=path_semantics,
                                          run_start=run_start)
@@ -158,7 +133,6 @@ class Registry(RegistryRO, RegistryTemplate):
     def insert_resource(self, spec, resource_path, resource_kwargs, root=None,
                         path_semantics='posix', uid=None, run_start=None,
                         id=None, ignore_duplicate_error=False):
-        self._create_resource_index()
         return super().insert_resource(spec, resource_path, resource_kwargs, root=root,
                                        path_semantics=path_semantics, uid=uid, run_start=run_start,
                                        id=id, ignore_duplicate_error=ignore_duplicate_error)

--- a/databroker/headersource/mongo.py
+++ b/databroker/headersource/mongo.py
@@ -15,10 +15,6 @@ class MDSRO(MDSROTemplate):
         super(MDSRO, self).__init__(config)
         self.reset_connection()
         self.auth = auth
-        self._runstart_index = False
-        self._runstop_index = False
-        self._descriptor_index = False
-        self._event_index = False
 
     def reset_connection(self):
         self.__db = None
@@ -46,51 +42,6 @@ class MDSRO(MDSROTemplate):
     def reconfigure(self, config):
         self.disconnect()
         super(MDSRO, self).reconfigure(config)
-
-    def _create_runstart_index(self):
-        if not self._runstart_index:
-            self._runstart_col.create_index([('uid', pymongo.DESCENDING)],
-                                             unique=True)
-            self._runstart_col.create_index([('time', pymongo.DESCENDING),
-                                              ('scan_id', pymongo.DESCENDING)],
-                                             unique=False, background=True)
-            self._runstart_col.create_index([("$**", "text")])
-            self._runstart_index = True
-
-    def _create_runstop_index(self):
-        if not self._runstop_index:
-            self._runstop_col.create_index('run_start',
-                                            unique=True)
-            self._runstop_col.create_index('uid',
-                                            unique=True)
-            self._runstop_col.create_index([('time', pymongo.DESCENDING)],
-                                            unique=False, background=True)
-            self._runstop_col.create_index([("$**", "text")])
-            self._runstop_index = True
-
-    def _create_descriptor_index(self):
-        if not self._descriptor_index:
-            # The name of the reference to the run start changed from
-            # 'run_start_id' in v0 to 'run_start' in v1.
-            rs_name = 'run_start'
-            self._descriptor_col.create_index([('uid', pymongo.DESCENDING)],
-                                               unique=True)
-            self._descriptor_col.create_index([(rs_name, pymongo.DESCENDING),
-                                                ('time', pymongo.DESCENDING)],
-                                               unique=False, background=True)
-            self._descriptor_col.create_index([('time', pymongo.DESCENDING)],
-                                               unique=False, background=True)
-            self._descriptor_col.create_index([("$**", "text")])
-            self._descriptor_index = True
-
-    def _create_event_index(self):
-        if not self._event_index:
-            self._event_col.create_index([('uid', pymongo.DESCENDING)],
-                                          unique=True)
-            self._event_col.create_index([('descriptor', pymongo.DESCENDING),
-                                           ('time', pymongo.ASCENDING)],
-                                          unique=False, background=True)
-            self._event_index = True
 
     @property
     def _connection(self):
@@ -187,27 +138,22 @@ class MDSRO(MDSROTemplate):
 class MDS(MDSRO, MDSTemplate):
 
     def insert_run_start(self, time, uid, **kwargs):
-        self._create_runstart_index()
         return super().insert_run_start(time, uid, **kwargs)
 
     def insert_run_stop(self, run_start, time, uid, exit_status='success',
                         reason='', **kwargs):
-        self._create_runstop_index()
         return super().insert_run_stop(run_start, time, uid, exit_status=exit_status,
                                        reason=reason, **kwargs)
 
     def insert_descriptor(self, run_start, data_keys, time, uid, **kwargs):
-        self._create_descriptor_index()
         return super().insert_descriptor(run_start, data_keys, time, uid, **kwargs)
 
     def insert_event(self, descriptor, time, seq_num, data, timestamps, uid,
                      validate=False, filled=None):
-        self._create_event_index()
         return super().insert_event(descriptor, time, seq_num, data, timestamps, uid,
                                     validate=validate, filled=filled)
 
     def bulk_insert_events(self, descriptor, events, validate=False):
-        self._create_event_index()
         return super().bulk_insert_events(descriptor, events, validate=validate)
 
     _INS_METHODS = {'start': 'insert_run_start',


### PR DESCRIPTION
When databroker was for both *writing* and reading it made some sense to put this here. Now it should be the job of writers (suitcase) or perhaps some separate separate, ops-oriented code.

If this did no harm it might make sense to leave it in v0, but it raises errors when it clashes with the evolving index creation in other repos, as illustrated in #600.

Closes #600 