### PR TITLE
Pin intake below 0.6.1.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,7 @@ dask[array,bag]
 doct
 event-model >=1.16.0
 humanize
-intake >=0.5.5
+intake >=0.5.5,<0.6.1
 jinja2
 jsonschema
 mongoquery


### PR DESCRIPTION
We see at least one critical bug against intake 0.6.1. This is a short term hotfix.