### PR TITLE
MergedCatalog is no longer working due to intake change

### DIFF
--- a/databroker/__init__.py
+++ b/databroker/__init__.py
@@ -3,7 +3,8 @@ import logging
 
 import intake  # noqa: F401
 from intake.catalog.default import load_combo_catalog
-from intake.catalog import MergedCatalog, EntrypointsCatalog
+from intake.catalog import MergedCatalog
+from intake.catalog.local import EntrypointsCatalog
 
 from .v1 import Broker, Header, ALL, temp, temp_config  # noqa: F401
 from .utils import (  # noqa: 401

--- a/databroker/__init__.py
+++ b/databroker/__init__.py
@@ -3,6 +3,7 @@ import logging
 
 import intake  # noqa: F401
 from intake.catalog.default import load_combo_catalog
+from intake.catalog import MergedCatalog
 
 from .v1 import Broker, Header, ALL, temp, temp_config  # noqa: F401
 from .utils import (  # noqa: 401
@@ -10,7 +11,7 @@ from .utils import (  # noqa: 401
     wrap_in_doct, DeprecatedDoct, wrap_in_deprecated_doct,  # noqa: F401
     catalog_search_path)  # noqa: F401
 
-from .discovery import MergedCatalog, EntrypointsCatalog, V0Catalog
+from .discovery import EntrypointsCatalog, V0Catalog
 
 
 logger = logging.getLogger(__name__)

--- a/databroker/__init__.py
+++ b/databroker/__init__.py
@@ -3,7 +3,7 @@ import logging
 
 import intake  # noqa: F401
 from intake.catalog.default import load_combo_catalog
-from intake.catalog import MergedCatalog
+from intake.catalog import MergedCatalog, EntrypointsCatalog
 
 from .v1 import Broker, Header, ALL, temp, temp_config  # noqa: F401
 from .utils import (  # noqa: 401
@@ -11,7 +11,7 @@ from .utils import (  # noqa: 401
     wrap_in_doct, DeprecatedDoct, wrap_in_deprecated_doct,  # noqa: F401
     catalog_search_path)  # noqa: F401
 
-from .discovery import EntrypointsCatalog, V0Catalog
+from .discovery import V0Catalog
 
 
 logger = logging.getLogger(__name__)

--- a/databroker/assets/sqlite.py
+++ b/databroker/assets/sqlite.py
@@ -166,7 +166,7 @@ class _ConnWrapper(object):
         self._c = None
 
     def __process_request_queue(self):
-        conn = sqlite3.connect(self._fp)
+        conn = sqlite3.connect(self._fp, timeout=30.0)
         # Return rows as objects that support getitem.
         conn.row_factory = sqlite3.Row
 

--- a/databroker/discovery.py
+++ b/databroker/discovery.py
@@ -1,8 +1,13 @@
 import collections
 from databroker.utils import list_configs, lookup_config, CONFIG_SEARCH_PATH
 import entrypoints
-from intake.catalog import Catalog, MergedCatalog
+from intake.catalog import Catalog
 from intake.catalog.entry import CatalogEntry
+
+# Import MergedCatalog from intake, so that code that relies on
+# databroker.discovery.MergedCatalog still works.
+from intake.catalog import MergedCatalog
+
 import warnings
 
 

--- a/databroker/discovery.py
+++ b/databroker/discovery.py
@@ -105,23 +105,3 @@ class V0Catalog(Catalog):
     def _load(self):
         for name in list_configs(paths=self._paths):
             self._entries[name] = V0Entry(name)
-
-
-class MergedCatalog(Catalog):
-    """
-    A Catalog that merges the entries of a list of catalogs.
-    """
-    # Work around
-    # https://github.com/intake/intake/issues/545
-    _container = None
-
-    def __init__(self, catalogs, *args, **kwargs):
-        self._catalogs = catalogs
-        super().__init__(*args, **kwargs)
-
-    def _load(self):
-        for catalog in self._catalogs:
-            catalog._load()
-
-    def _make_entries_container(self):
-        return collections.ChainMap(*(catalog._entries for catalog in self._catalogs))

--- a/databroker/discovery.py
+++ b/databroker/discovery.py
@@ -1,7 +1,7 @@
 import collections
 from databroker.utils import list_configs, lookup_config, CONFIG_SEARCH_PATH
 import entrypoints
-from intake.catalog import Catalog
+from intake.catalog import Catalog, MergedCatalog
 from intake.catalog.entry import CatalogEntry
 import warnings
 

--- a/databroker/discovery.py
+++ b/databroker/discovery.py
@@ -4,9 +4,10 @@ import entrypoints
 from intake.catalog import Catalog
 from intake.catalog.entry import CatalogEntry
 
-# Import MergedCatalog from intake, so that code that relies on
-# databroker.discovery.MergedCatalog still works.
-from intake.catalog import MergedCatalog, EntrypointsCatalog, EntrypointEntry
+# Import from intake, so that code that relies on
+# databroker.discovery.MergedCatalog, etc. still works.
+from intake.catalog import MergedCatalog, EntrypointsCatalog
+from intake.catalog.local import EntrypointEntry
 
 import warnings
 

--- a/databroker/discovery.py
+++ b/databroker/discovery.py
@@ -6,67 +6,9 @@ from intake.catalog.entry import CatalogEntry
 
 # Import MergedCatalog from intake, so that code that relies on
 # databroker.discovery.MergedCatalog still works.
-from intake.catalog import MergedCatalog
+from intake.catalog import MergedCatalog, EntrypointsCatalog, EntrypointEntry
 
 import warnings
-
-
-class EntrypointEntry(CatalogEntry):
-    """
-    A catalog entry for an entrypoint.
-    """
-    # Work around
-    # https://github.com/intake/intake/issues/545
-    _container = None
-
-    def __init__(self, entrypoint):
-        self._entrypoint = entrypoint
-
-    def __repr__(self):
-        return f"<Entry containing Catalog named {self.name}>"
-
-    @property
-    def name(self):
-        return self._entrypoint.name
-
-    def describe(self):
-        """Basic information about this entry"""
-        return {'name': self.name,
-                'module_name': self._entrypoint.module_name,
-                'object_name': self._entrypoint.object_name,
-                'distro': self._entrypoint.distro,
-                'extras': self._entrypoint.extras}
-
-    def get(self):
-        """Instantiate the DataSource for the given parameters"""
-        return self._entrypoint.load()
-
-
-class EntrypointsCatalog(Catalog):
-    """
-    A catalog of discovered entrypoint catalogs.
-    """
-    # Work around
-    # https://github.com/intake/intake/issues/545
-    _container = None
-
-    def __init__(self, *args, entrypoints_group='intake.catalogs', paths=None,
-                 **kwargs):
-        self._entrypoints_group = entrypoints_group
-        self._paths = paths
-        super().__init__(*args, **kwargs)
-
-    def _load(self):
-        catalogs = entrypoints.get_group_named(self._entrypoints_group,
-                                               path=self._paths)
-        self.name = self.name or 'EntrypointsCatalog'
-        self.description = (self.description
-                            or f'EntrypointsCatalog of {len(catalogs)} catalogs.')
-        for name, entrypoint in catalogs.items():
-            try:
-                self._entries[name] = EntrypointEntry(entrypoint)
-            except Exception as e:
-                warnings.warn(f"Failed to load {name}, {entrypoint}, {e!r}.")
 
 
 class V0Entry(CatalogEntry):

--- a/databroker/discovery.py
+++ b/databroker/discovery.py
@@ -1,15 +1,11 @@
-import collections
 from databroker.utils import list_configs, lookup_config, CONFIG_SEARCH_PATH
-import entrypoints
 from intake.catalog import Catalog
 from intake.catalog.entry import CatalogEntry
 
 # Import from intake, so that code that relies on
 # databroker.discovery.MergedCatalog, etc. still works.
-from intake.catalog import MergedCatalog, EntrypointsCatalog
-from intake.catalog.local import EntrypointEntry
-
-import warnings
+from intake.catalog import MergedCatalog, EntrypointsCatalog  # noqa: F401
+from intake.catalog.local import EntrypointEntry  # noqa: F401
 
 
 class V0Entry(CatalogEntry):

--- a/databroker/headersource/sqlite.py
+++ b/databroker/headersource/sqlite.py
@@ -94,7 +94,7 @@ class EventCollection(object):
                 continue
             uid, = match.groups()
             fp = os.path.join(self._dirpath, fn)
-            conn = sqlite3.connect(fp)
+            conn = sqlite3.connect(fp, timeout=30.0)
             # Return rows as objects that support getitem.
             conn.row_factory = sqlite3.Row
             self._runstarts[uid] = conn
@@ -269,7 +269,7 @@ class EventCollection(object):
     def _insert_start(self, doc):
         uid = doc['uid']
         fp = os.path.join(self._dirpath, '{}.sqlite'.format(uid))
-        conn = sqlite3.connect(fp)
+        conn = sqlite3.connect(fp, timeout=30.0)
         conn.row_factory = sqlite3.Row
         self._runstarts[uid] = conn
 


### PR DESCRIPTION
With the latest release of intake 0.6.1 we see this problem:

![image](https://user-images.githubusercontent.com/11858848/108395990-5a83c780-71e4-11eb-9b4e-a0d6202ca9ac.png)

It should behave like this:

![image](https://user-images.githubusercontent.com/11858848/108396212-9a4aaf00-71e4-11eb-9b6d-df93a84e09f4.png)

This PR fixes the problem.