### PR TITLE
fix import error for older intake version

### DIFF
--- a/databroker/__init__.py
+++ b/databroker/__init__.py
@@ -3,8 +3,7 @@ import logging
 
 import intake  # noqa: F401
 from intake.catalog.default import load_combo_catalog
-from intake.catalog import MergedCatalog
-from intake.catalog.local import EntrypointsCatalog
+from intake.catalog.local import MergedCatalog, EntrypointsCatalog
 
 from .v1 import Broker, Header, ALL, temp, temp_config  # noqa: F401
 from .utils import (  # noqa: 401

--- a/databroker/discovery.py
+++ b/databroker/discovery.py
@@ -4,7 +4,7 @@ from intake.catalog.entry import CatalogEntry
 
 # Import from intake, so that code that relies on
 # databroker.discovery.MergedCatalog, etc. still works.
-from intake.catalog import MergedCatalog, EntrypointsCatalog  # noqa: F401
+from intake.catalog.local import MergedCatalog, EntrypointsCatalog  # noqa: F401
 from intake.catalog.local import EntrypointEntry  # noqa: F401
 
 


### PR DESCRIPTION
Import MergedCatalog from a better location so that it still works with older intake versions