### PR TITLE
Fix format string; add authsource option

### DIFF
--- a/databroker/v1.py
+++ b/databroker/v1.py
@@ -1680,9 +1680,12 @@ def _get_mongo_database(config):
     # This is only here for backward compatibility.
     if {'mongo_user', 'mongo_pwd', 'host', 'port'} <= set(config):
         uri = (f"mongodb://{config['mongo_user']}:{config['mongo_pwd']}@"
-               "f{config['host']}:{config['port']}/")
+               f"{config['host']}:{config['port']}/")
 
     if uri:
+        if 'authsource' in config:
+            uri += f'?authsource={config["authsource"]}'
+
         try:
             client = _mongo_clients[uri]
         except KeyError:


### PR DESCRIPTION
This corrects a typo in the format string for mongodb uris, and also adds an optional authsource configuration to the connection string.
@dylanmcreynolds @JulReinhardt @ihumphrey 