### PR TITLE
Drop python 3.6 support, and skip dask 2021.3.0

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -16,7 +16,7 @@ jobs:
         - 27017:27017
     strategy:
       matrix:
-        python-version: [3.6, 3.7, 3.8]
+        python-version: [3.7, 3.8, 3.9]
         intake-version: ["master", "latest"]
       fail-fast: false
     steps:

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -4,7 +4,7 @@ codecov
 coverage
 flake8
 glueviz
-intake[server] !=0.6.2
+intake[server]
 matplotlib
 mongomock
 numpy >=1.16.0  # for astropy (via glueviz)

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -4,7 +4,7 @@ codecov
 coverage
 flake8
 glueviz
-intake[server]
+intake[server] !=0.6.2
 matplotlib
 mongomock
 numpy >=1.16.0  # for astropy (via glueviz)

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,7 @@ dask[array,bag]
 doct
 event-model >=1.16.0
 humanize
-intake >=0.5.5
+intake >=0.5.5, !=0.6.2
 jinja2
 jsonschema
 mongoquery

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,7 @@ dask[array,bag] != 2021.3.0
 doct
 event-model >=1.16.0
 humanize
-intake >=0.5.5, !=0.6.2
+intake >=0.5.5
 jinja2
 jsonschema
 mongoquery

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 bluesky-live
 boltons
 cachetools
-dask[array,bag]
+dask[array,bag] != 2021.3.0
 doct
 event-model >=1.16.0
 humanize


### PR DESCRIPTION
We are seeing CI failures due to the latest intake release 0.6.2, and also from dask 2021.3.0.
Intake no longer supports python 3.6. 
This PR drops support for python 3.6, in accordance with https://numpy.org/neps/nep-0029-deprecation_policy.html
I turned off the CI for python 3.6, and turned on the CI for 3.9