### PR TITLE
Use v2.temp to be self-consistent in docs.

### DIFF
--- a/docs/source/how-to/file-backed-catalog.rst
+++ b/docs/source/how-to/file-backed-catalog.rst
@@ -32,7 +32,7 @@ especially large) there.
 
 .. code:: python
 
-   from databroker import temp
+   from databroker.v2 import temp
    catalog = temp()
    # That's it!
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

All of the documented examples use the v2 interface. We should use a v2-compatible temporary databroker for self-consistency.
