### PR TITLE
FIX: fix metadata access from a run via attribute

### DIFF
--- a/databroker/v1.py
+++ b/databroker/v1.py
@@ -893,7 +893,7 @@ class Header:
     @property
     def stop(self):
         if self._stop is None:
-            self._stop = self._run['metadata']['stop'] or {}
+            self._stop = self._run.metadata['stop'] or {}
         return self.db.prepare_hook('stop', self._stop)
 
     def __eq__(self, other):


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
This PR fixes an issue with accessing `run.metadata` in the stop document.

## Description
<!--- Describe your changes in detail -->
A small update to access metadata properly.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Internal NSLS-II JIRA report for the CSX beamline.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Nothing yet.

<!--
## Screenshots (if appropriate):
-->
