### PR TITLE
don't use intake v0.6.5, and get the CI passing

### DIFF
--- a/databroker/assets/core.py
+++ b/databroker/assets/core.py
@@ -116,7 +116,7 @@ def bulk_insert_datum(col, resource, datum_ids,
             apply_to_dict_recursively(datum, sanitize_np)
             yield datum
 
-    col.insert(datum_factory())
+    col.insert_many(datum_factory())
 
 
 def bulk_register_datum_table(datum_col,

--- a/databroker/assets/sqlite.py
+++ b/databroker/assets/sqlite.py
@@ -264,6 +264,9 @@ class DatumCollection(object):
         with cursor(self._conn) as c:
             c.execute(INSERT_DATUM, [datum[k] for k in keys])
 
+    def insert_many(self, datums):
+        self.insert(datums)
+
     def insert(self, datums):
         datums = map(lambda d: shadow_with_json(d, ['datum_kwargs']), datums)
         keys = ['datum_id', 'datum_kwargs', 'resource']

--- a/databroker/headersource/core.py
+++ b/databroker/headersource/core.py
@@ -755,7 +755,7 @@ def bulk_insert_events(event_col, descriptor, events, validate):
                           seq_num=int(ev['seq_num']))
             yield ev_out
 
-    return event_col.insert(event_factory())
+    return event_col.insert_many(event_factory())
 
 
 # DATABASE RETRIEVAL ##########################################################

--- a/databroker/headersource/hdf5.py
+++ b/databroker/headersource/hdf5.py
@@ -107,6 +107,9 @@ class EventCollection(object):
         # not used on event_col
         return self.insert([doc])
 
+    def insert_many(self, docs):
+        return self.insert(docs)
+
     def insert(self, docs):
         # Sort docs by descriptor.
         descs = defaultdict(list)

--- a/databroker/headersource/sqlite.py
+++ b/databroker/headersource/sqlite.py
@@ -190,6 +190,9 @@ class EventCollection(object):
     def insert_one(self, doc):
         self.insert([doc])
 
+    def insert_many(self, docs):
+        self.insert(docs)
+
     def insert(self, docs):
         success_event = threading.Event()
         ret = {}

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -4,7 +4,7 @@ codecov
 coverage
 flake8
 glueviz
-intake[server]
+intake[server] <=0.6.4
 matplotlib
 mongomock
 numpy >=1.16.0  # for astropy (via glueviz)

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,7 +14,7 @@ msgpack-numpy  # to be split into extras or a separate package
 numpy
 pandas
 pims
-pymongo <4 # to be split into extras or a separate package
+pymongo >3.0 # to be split into extras or a separate package
 pytz
 pyyaml
 requests

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,7 +14,7 @@ msgpack-numpy  # to be split into extras or a separate package
 numpy
 pandas
 pims
-pymongo >3.0 # to be split into extras or a separate package
+pymongo >=3.0 # to be split into extras or a separate package
 pytz
 pyyaml
 requests

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,7 @@ dask[array,bag]
 doct
 event-model >=1.16.0
 humanize
-intake >=0.5.5
+intake >=0.5.5, <=0.6.4
 jinja2
 jsonschema
 mongoquery

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,7 +14,7 @@ msgpack-numpy  # to be split into extras or a separate package
 numpy
 pandas
 pims
-pymongo  # to be split into extras or a separate package
+pymongo <4 # to be split into extras or a separate package
 pytz
 pyyaml
 requests


### PR DESCRIPTION
Intake 0.6.5 seems to have a bug in it causing errors in databroker.
So the CI run against intake master is expected to fail.
See issue https://github.com/intake/intake/issues/643

Pymongo 4 dropped `Collection.insert()` so we have to use `Collection.insert_one()` or `Collection.insert_many()`
