### PR TITLE
FIX: the back-compat getattr shim in databroker

### DIFF
--- a/databroker/__init__.py
+++ b/databroker/__init__.py
@@ -72,7 +72,10 @@ def __getattr__(name):
             from .pims_readers import get_images
 
             return get_images
-        return getattr(utils, name)
+
+        from . import databroker
+        return getattr(databroker, name)
+
     raise AttributeError(name)
 
 


### PR DESCRIPTION
The back-compat shim needs to fallback to the nested databroker sub-module not utils.