### PR TITLE
[Experimental backend] Support chunked upload and sparse arrays

### DIFF
--- a/databroker/experimental/schemas.py
+++ b/databroker/experimental/schemas.py
@@ -5,6 +5,7 @@ import pydantic.generics
 
 from tiled.server.pydantic_array import ArrayStructure
 from tiled.server.pydantic_dataframe import DataFrameStructure
+from tiled.server.pydantic_sparse import SparseStructure
 from tiled.structures.core import StructureFamily
 
 
@@ -13,6 +14,7 @@ from tiled.structures.core import StructureFamily
 structure_association = {
     StructureFamily.array: ArrayStructure,
     StructureFamily.dataframe: DataFrameStructure,
+    StructureFamily.sparse: SparseStructure,
     # StructureFamily.node
     # ...
 }
@@ -21,7 +23,7 @@ structure_association = {
 class Document(pydantic.BaseModel):
     key: str
     structure_family: StructureFamily
-    structure: Union[ArrayStructure, DataFrameStructure]
+    structure: Union[ArrayStructure, DataFrameStructure, SparseStructure]
     metadata: Dict
     specs: List[str]
     mimetype: str

--- a/databroker/experimental/server_ext.py
+++ b/databroker/experimental/server_ext.py
@@ -1,5 +1,6 @@
 import collections.abc
 import os
+import shutil
 import uuid
 from pathlib import Path
 
@@ -120,7 +121,7 @@ class WritingArrayAdapter:
         self.array[slice_] = array
 
     def delete(self):
-        safe_path(self.doc.data_uri.path).unlink()
+        shutil.rmtree(safe_path(self.doc.data_url.path))
         result = self.collection.delete_one({"key": self.doc.key})
         assert result.deleted_count == 1
 
@@ -132,7 +133,10 @@ class WritingDataFrameAdapter:
         self.collection = collection
         self.doc = doc
         assert self.doc.data_blob is None  # not implemented
-        self.dataframe_adapter = DataFrameAdapter.from_dask_dataframe(
+
+    @property
+    def dataframe_adapter(self):
+        return DataFrameAdapter.from_dask_dataframe(
             dask.dataframe.read_parquet(safe_path(self.doc.data_url.path))
         )
 
@@ -174,7 +178,7 @@ class WritingDataFrameAdapter:
         )
 
     def delete(self):
-        safe_path(self.doc.data_url.path).unlink()
+        shutil.rmtree(safe_path(self.doc.data_url.path))
         result = self.collection.delete_one({"key": self.doc.key})
         assert result.deleted_count == 1
 

--- a/databroker/tests/test_experimental.py
+++ b/databroker/tests/test_experimental.py
@@ -32,7 +32,7 @@ def test_write_array(tmpdir):
 
     metadata = {"scan_id": 1, "method": "A"}
     specs = ["SomeSpec"]
-    client.write_array(test_array, metadata, specs)
+    client.write_array(test_array, metadata=metadata, specs=specs)
 
     results = client.search(Key("scan_id") == 1)
     result = results.values().first()
@@ -68,7 +68,7 @@ def test_write_dataframe(tmpdir):
     metadata = {"scan_id": 1, "method": "A"}
     specs = ["SomeSpec"]
 
-    client.write_dataframe(test_dataframe, metadata, specs)
+    client.write_dataframe(test_dataframe, metadata=metadata, specs=specs)
 
     results = client.search(Key("scan_id") == 1)
     result = results.values().first()
@@ -96,7 +96,7 @@ def test_queries(tmpdir):
         metadata = {"letter": letter, "number": number}
         array = number * numpy.ones(10)
 
-        client.write_array(array, metadata)
+        client.write_array(array, metadata=metadata)
 
     test1 = client.search(Eq("letter", "a"))
     numpy.testing.assert_equal(
@@ -159,7 +159,7 @@ def test_delete(tmpdir):
     test_dataframe = pandas.DataFrame(data)
 
     arr_key = client.write_dataframe(
-        test_dataframe, {"scan_id": 1, "method": "A"}, ["BlueskyNode"]
+        test_dataframe, metadata={"scan_id": 1, "method": "A"}, specs=["BlueskyNode"]
     )
 
     del client[arr_key]
@@ -170,7 +170,7 @@ def test_delete(tmpdir):
     test_array = numpy.ones((5, 5))
 
     df_key = client.write_array(
-        test_array, {"scan_id": 1, "method": "A"}, ["BlueskyNode"]
+        test_array, metadata={"scan_id": 1, "method": "A"}, specs=["BlueskyNode"]
     )
 
     del client[df_key]

--- a/databroker/tests/test_experimental.py
+++ b/databroker/tests/test_experimental.py
@@ -158,21 +158,21 @@ def test_delete(tmpdir):
 
     test_dataframe = pandas.DataFrame(data)
 
-    arr_key = client.write_dataframe(
+    x = client.write_dataframe(
         test_dataframe, metadata={"scan_id": 1, "method": "A"}, specs=["BlueskyNode"]
     )
 
-    del client[arr_key]
+    del client[x.item["id"]]
 
-    assert arr_key not in client
+    assert x.item["id"] not in client
 
     # For arrays
     test_array = numpy.ones((5, 5))
 
-    df_key = client.write_array(
+    y = client.write_array(
         test_array, metadata={"scan_id": 1, "method": "A"}, specs=["BlueskyNode"]
     )
 
-    del client[df_key]
+    del client[y.item["id"]]
 
-    assert df_key not in client
+    assert y.item["id"] not in client

--- a/databroker/tests/test_experimental.py
+++ b/databroker/tests/test_experimental.py
@@ -1,3 +1,10 @@
+import string
+
+import dask.array
+import dask.dataframe
+import numpy
+import pandas
+import sparse
 from tiled.client import from_tree
 from tiled.queries import (
     Contains,
@@ -10,25 +17,23 @@ from tiled.queries import (
     NotIn,
     Regex,
 )
+from tiled.structures.sparse import COOStructure
 
 from ..experimental.server_ext import MongoAdapter
 
-import numpy
-import pandas
-import string
+
+API_KEY = "secret"
 
 
 def test_write_array(tmpdir):
 
-    api_key = "secret"
-
     tree = MongoAdapter.from_mongomock(tmpdir)
 
     client = from_tree(
-        tree, api_key=api_key, authentication={"single_user_api_key": api_key}
+        tree, api_key=API_KEY, authentication={"single_user_api_key": API_KEY}
     )
 
-    test_array = numpy.ones((5, 5))
+    test_array = numpy.ones((5, 7))
 
     metadata = {"scan_id": 1, "method": "A"}
     specs = ["SomeSpec"]
@@ -46,15 +51,13 @@ def test_write_array(tmpdir):
 
 def test_write_dataframe(tmpdir):
 
-    api_key = "secret"
-
     tree = MongoAdapter.from_mongomock(tmpdir)
 
     client = from_tree(
-        tree, api_key=api_key, authentication={"single_user_api_key": api_key}
+        tree, api_key=API_KEY, authentication={"single_user_api_key": API_KEY}
     )
 
-    dummy_array = numpy.ones((5, 5))
+    dummy_array = numpy.ones((5, 7))
 
     data = {
         "Column1": dummy_array[0],
@@ -82,12 +85,10 @@ def test_write_dataframe(tmpdir):
 
 def test_queries(tmpdir):
 
-    api_key = "secret"
-
     tree = MongoAdapter.from_mongomock(tmpdir)
 
     client = from_tree(
-        tree, api_key=api_key, authentication={"single_user_api_key": api_key}
+        tree, api_key=API_KEY, authentication={"single_user_api_key": API_KEY}
     )
 
     keys = list(string.ascii_lowercase)
@@ -137,12 +138,9 @@ def test_queries(tmpdir):
 
 def test_delete(tmpdir):
 
-    api_key = "secret"
-
     tree = MongoAdapter.from_mongomock(tmpdir)
-
     client = from_tree(
-        tree, api_key=api_key, authentication={"single_user_api_key": api_key}
+        tree, api_key=API_KEY, authentication={"single_user_api_key": API_KEY}
     )
 
     # For dataframes
@@ -176,3 +174,112 @@ def test_delete(tmpdir):
     del client[y.item["id"]]
 
     assert y.item["id"] not in client
+
+
+def test_write_array_chunked(tmpdir):
+
+    tree = MongoAdapter.from_mongomock(tmpdir)
+    client = from_tree(
+        tree, api_key=API_KEY, authentication={"single_user_api_key": API_KEY}
+    )
+
+    a = dask.array.arange(24).reshape((4, 6)).rechunk((2, 3))
+
+    metadata = {"scan_id": 1, "method": "A"}
+    specs = ["SomeSpec"]
+    client.write_array(a, metadata=metadata, specs=specs)
+
+    results = client.search(Key("scan_id") == 1)
+    result = results.values().first()
+    result_array = result.read()
+
+    numpy.testing.assert_equal(result_array, a.compute())
+    assert result.metadata == metadata
+    assert result.specs == specs
+
+
+def test_write_dataframe_partitioned(tmpdir):
+
+    tree = MongoAdapter.from_mongomock(tmpdir)
+    client = from_tree(
+        tree, api_key=API_KEY, authentication={"single_user_api_key": API_KEY}
+    )
+
+    data = {f"Column{i}": (1 + i) * numpy.ones(10) for i in range(5)}
+    df = pandas.DataFrame(data)
+    ddf = dask.dataframe.from_pandas(df, npartitions=3)
+    metadata = {"scan_id": 1, "method": "A"}
+    specs = ["SomeSpec"]
+
+    client.write_dataframe(ddf, metadata=metadata, specs=specs)
+
+    results = client.search(Key("scan_id") == 1)
+    result = results.values().first()
+    result_dataframe = result.read()
+
+    pandas.testing.assert_frame_equal(result_dataframe, df)
+    assert result.metadata == metadata
+    # TODO In the future this will be accessible via result.specs.
+    assert result.item["attributes"]["specs"] == specs
+
+
+def test_write_sparse_full(tmpdir):
+
+    tree = MongoAdapter.from_mongomock(tmpdir)
+    client = from_tree(
+        tree, api_key=API_KEY, authentication={"single_user_api_key": API_KEY}
+    )
+
+    coo = sparse.COO(coords=[[0, 1], [2, 3]], data=[3.8, 4.0], shape=(4, 4))
+
+    metadata = {"scan_id": 1, "method": "A"}
+    specs = ["SomeSpec"]
+    client.write_sparse(
+        coords=coo.coords,
+        data=coo.data,
+        shape=coo.shape,
+        metadata=metadata,
+        specs=specs,
+    )
+
+    results = client.search(Key("scan_id") == 1)
+    result = results.values().first()
+    result_array = result.read()
+
+    numpy.testing.assert_equal(result_array.todense(), coo.todense())
+    assert result.metadata == metadata
+    assert result.specs == specs
+
+
+def test_write_sparse_chunked(tmpdir):
+
+    tree = MongoAdapter.from_mongomock(tmpdir)
+    client = from_tree(
+        tree, api_key=API_KEY, authentication={"single_user_api_key": API_KEY}
+    )
+
+    metadata = {"scan_id": 1, "method": "A"}
+    specs = ["SomeSpec"]
+    N = 5
+    x = client.new(
+        "sparse",
+        COOStructure(shape=(2 * N,), chunks=((N, N),)),
+        metadata=metadata,
+        specs=specs,
+    )
+    x.write_block(coords=[[2, 4]], data=[3.1, 2.8], block=(0,))
+    x.write_block(coords=[[0, 1]], data=[6.7, 1.2], block=(1,))
+
+    results = client.search(Key("scan_id") == 1)
+    result = results.values().first()
+    result_array = result.read()
+    assert numpy.array_equal(
+        result_array.todense(),
+        sparse.COO(
+            coords=[[2, 4, N + 0, N + 1]], data=[3.1, 2.8, 6.7, 1.2], shape=(10,)
+        ).todense(),
+    )
+
+    # numpy.testing.assert_equal(result_array, sparse.COO(coords=[0, 1, ]))
+    assert result.metadata == metadata
+    assert result.specs == specs

--- a/requirements-client.txt
+++ b/requirements-client.txt
@@ -1,3 +1,3 @@
 mongoquery
 msgpack >=1.0.0
-tiled[client] >=0.1.0a66
+tiled[client] >=0.1.0a67

--- a/requirements-server.txt
+++ b/requirements-server.txt
@@ -13,3 +13,4 @@ starlette
 tiled[server] >=0.1.0a67
 toolz
 tzlocal
+zarr

--- a/requirements-server.txt
+++ b/requirements-server.txt
@@ -10,6 +10,6 @@ pydantic
 pymongo
 pytz
 starlette
-tiled[server] >=0.1.0a66
+tiled[server] >=0.1.0a67
 toolz
 tzlocal

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -16,6 +16,6 @@ sphinx
 suitcase-jsonl >=0.1.0b2
 suitcase-mongo >=0.1.0
 suitcase-msgpack >=0.2.2
-tiled[all]
+tiled[all] >=0.1.0a67
 ujson
 vcrpy


### PR DESCRIPTION
This PR changes only the alpha experimental backend.

This PR switches from HDF5 for Zarr for array storage because the latter has first-class support for concurrent writes of non-overlapping chunks. For DataFrame storage, it continues to rely on parquet, but it switches from a single parquet file to a directory of parquet file(s), supporting partitioned data.

It also adds support for Tiled's new `sparse` structure family, backed also be a directory of parquet files.