### PR TITLE
Fix slicing into WritableDataFrameAdapter.

### DIFF
--- a/databroker/experimental/server_ext.py
+++ b/databroker/experimental/server_ext.py
@@ -14,6 +14,7 @@ import zarr
 import zarr.storage
 
 from tiled.adapters.array import slice_and_shape_from_block_and_chunks
+from tiled.adapters.array import ArrayAdapter
 from tiled.adapters.dataframe import DataFrameAdapter
 from tiled.adapters.mapping import MapAdapter
 from tiled.adapters.utils import IndexersMixin, tree_repr
@@ -160,6 +161,9 @@ class WritingDataFrameAdapter:
     @property
     def specs(self):
         return self.doc.specs
+
+    def __getitem__(self, key):
+        return ArrayAdapter(self.dataframe_adapter.read([key])[key].values)
 
     def read(self, *args, **kwargs):
         return self.dataframe_adapter.read(*args, **kwargs)

--- a/databroker/tests/test_experimental.py
+++ b/databroker/tests/test_experimental.py
@@ -78,6 +78,9 @@ def test_write_dataframe(tmpdir):
     result_dataframe = result.read()
 
     pandas.testing.assert_frame_equal(result_dataframe, test_dataframe)
+    # slicing into DataFrameClient returns ArrayClient
+    result_array = result["Column1"][:]
+    assert numpy.array_equal(result_array, dummy_array[0])
     assert result.metadata == metadata
     # TODO In the future this will be accessible via result.specs.
     assert result.item["attributes"]["specs"] == specs


### PR DESCRIPTION
Slicing into an DataFrameClient should return an ArrayClient. This was not implemented in the experimental server, and failed like so:

```py
In [3]: c
Out[3]: <Node {'5804f003-6faf-43f2-8406-01533619f032', ...} ~3 entries>

In [4]: import pandas

In [5]: df = pandas.DataFrame({"a": [1,2,3], "b": [4,5,6]})

In [6]: x = c.write_dataframe(df)
Out[6]: <DataFrameClient ['a', 'b']>

In [8]: x
Out[8]: <DataFrameClient ['a', 'b']>

In [9]: x.read()
Out[9]: 
   a  b
0  1  4
1  2  5
2  3  6

In [10]: list(x)
Out[10]: ['a', 'b']

In [11]: x['a']
---------------------------------------------------------------------------
HTTPStatusError                           Traceback (most recent call last)
~/Repos/bnl/tiled/tiled/client/utils.py in handle_error(response)
     24     try:
---> 25         response.raise_for_status()
     26     except httpx.RequestError:

~/miniconda3/envs/py38/lib/python3.8/site-packages/httpx/_models.py in raise_for_status(self)
   1507         message = message.format(self, error_type=error_type)
-> 1508         raise HTTPStatusError(message, request=request, response=self)
   1509 

HTTPStatusError: Client error '404 Not Found' for url 'http://127.0.0.1:8000/api/node/metadata/4f5c3f81-c681-4637-897d-a40591cba201/a'
For more information check: https://httpstatuses.com/404

The above exception was the direct cause of the following exception:

ClientError                               Traceback (most recent call last)
~/Repos/bnl/tiled/tiled/client/dataframe.py in __getitem__(self, column)
    169                 self_link = self_link[:-1]
--> 170             content = self.context.get_json(
    171                 self_link + f"/{column}",

~/Repos/bnl/tiled/tiled/client/context.py in get_json(self, path, stream, **kwargs)
    517         return msgpack.unpackb(
--> 518             self.get_content(
    519                 path, accept="application/x-msgpack", stream=stream, **kwargs

~/Repos/bnl/tiled/tiled/client/context.py in get_content(self, path, accept, stream, revalidate, **kwargs)
    444             response = self._send(request, stream=stream)
--> 445             handle_error(response)
    446             if response.headers.get("content-encoding") == "blosc":

~/Repos/bnl/tiled/tiled/client/utils.py in handle_error(response)
     39             message = f"{exc.response.status_code}: " f"{detail} " f"{exc.request.url}"
---> 40             raise ClientError(message, exc.request, exc.response) from exc
     41         else:

ClientError: 404: No such entry: ['4f5c3f81-c681-4637-897d-a40591cba201', 'a'] http://127.0.0.1:8000/api/node/metadata/4f5c3f81-c681-4637-897d-a40591cba201/a

During handling of the above exception, another exception occurred:

KeyError                                  Traceback (most recent call last)
<ipython-input-11-be3a3d3e2373> in <module>
----> 1 x['a']

~/Repos/bnl/tiled/tiled/client/dataframe.py in __getitem__(self, column)
    173         except ClientError as err:
    174             if err.response.status_code == 404:
--> 175                 raise KeyError(column)
    176             raise
    177         item = content["data"]

KeyError: 'a'
```