### PR TITLE
Fix temp.

### DIFF
--- a/databroker/v2.py
+++ b/databroker/v2.py
@@ -14,9 +14,9 @@ def temp():
     This is intended for testing, teaching, an demos. The data does not
     persistent. Do not use this for anything important.
     """
-    from .mongo_normalized import Catalog
-    from tiled.client import from_catalog
+    from .mongo_normalized import MongoAdapter
+    from tiled.client import from_tree
 
-    catalog = Catalog.from_mongomock()  # service-side Catalog
-    client = from_catalog(catalog)  # client-side Catalog
+    catalog = MongoAdapter.from_mongomock()  # service-side Catalog
+    client = from_tree(catalog)  # client-side Catalog
     return client


### PR DESCRIPTION
Closes #725 

Apparently `temp()` had no test coverage. A name change during the alpha stage of databroker 2.x development wasn't applied in the module `databroker.v2`. This fixes `databroker.v2.temp` and `databroker.v1.temp`.

```py
In [1]: import databroker.v1

In [2]: import databroker.v2

In [3]: databroker.v1.temp()
OBJECT CACHE: Will use up to 6_290_642_534 bytes (15% of total physical RAM)
Out[3]: <databroker.v1.Broker at 0x7fcdbcc49f10>

In [4]: databroker.v2.temp()
OBJECT CACHE: Will use up to 6_290_642_534 bytes (15% of total physical RAM)
Out[4]: <Catalog {}>
```
