### PR TITLE
Added and implemented new references schema

### DIFF
--- a/databroker/experimental/schemas.py
+++ b/databroker/experimental/schemas.py
@@ -9,6 +9,7 @@ from tiled.server.pydantic_dataframe import DataFrameStructure
 from tiled.server.pydantic_sparse import SparseStructure
 from tiled.structures.core import StructureFamily
 
+from tiled.server.schemas import ReferenceDocument
 
 # Map structure family to the associated
 # structure model. This is used by the validator.
@@ -25,6 +26,7 @@ class BaseDocument(pydantic.BaseModel):
     key: str
     metadata: Dict
     specs: List[str]
+    references: List[ReferenceDocument]
     updated_at: datetime
 
 
@@ -93,6 +95,7 @@ class DocumentRevision(BaseDocument):
             key=document.key,
             metadata=document.metadata,
             specs=document.specs,
+            references=document.references,
             updated_at=document.updated_at,
             revision=revision,
         )
@@ -103,6 +106,7 @@ class DocumentRevision(BaseDocument):
             key=json_doc["key"],
             metadata=json_doc["metadata"],
             specs=json_doc["specs"],
+            references=json_doc["references"],
             updated_at=json_doc["updated_at"],
             revision=json_doc["revision"],
         )

--- a/databroker/server.py
+++ b/databroker/server.py
@@ -2,7 +2,7 @@ import json
 import msgpack
 from typing import Optional
 
-from fastapi import APIRouter, HTTPException, Request, Security
+from fastapi import APIRouter, HTTPException, Request
 import pydantic
 from tiled.server.core import PatchedStreamingResponse
 from tiled.server.dependencies import SecureEntry

--- a/databroker/server.py
+++ b/databroker/server.py
@@ -5,7 +5,7 @@ from typing import Optional
 from fastapi import APIRouter, HTTPException, Request, Security
 import pydantic
 from tiled.server.core import PatchedStreamingResponse
-from tiled.server.dependencies import entry
+from tiled.server.dependencies import SecureEntry
 
 
 class NameDocumentPair(pydantic.BaseModel):
@@ -21,7 +21,7 @@ router = APIRouter()
 def documents(
     request: Request,
     fill: Optional[bool] = False,
-    run=Security(entry, scopes=["read:data", "read:metadata"]),
+    run=SecureEntry(scopes=["read:data", "read:metadata"]),
 ):
     # Check that this is a BlueskyRun.
     if not hasattr(run, "documents"):

--- a/databroker/tests/test_experimental.py
+++ b/databroker/tests/test_experimental.py
@@ -18,6 +18,7 @@ from tiled.queries import (
     Regex,
 )
 from tiled.structures.sparse import COOStructure
+from tiled.validation_registration import ValidationRegistry
 
 from ..experimental.server_ext import MongoAdapter
 
@@ -25,6 +26,10 @@ from ..experimental.schemas import DocumentRevision
 
 
 API_KEY = "secret"
+validation_registry = ValidationRegistry()
+validation_registry.register("SomeSpec", lambda *args, **kwargs: None)
+validation_registry.register("AnotherSpec", lambda *args, **kwargs: None)
+validation_registry.register("AnotherOtherSpec", lambda *args, **kwargs: None)
 
 
 def test_write_array(tmpdir):
@@ -32,7 +37,8 @@ def test_write_array(tmpdir):
     tree = MongoAdapter.from_mongomock(tmpdir)
 
     client = from_tree(
-        tree, api_key=API_KEY, authentication={"single_user_api_key": API_KEY}
+        tree, api_key=API_KEY, authentication={"single_user_api_key": API_KEY},
+        validation_registry=validation_registry,
     )
 
     test_array = numpy.ones((5, 7))
@@ -60,7 +66,8 @@ def test_write_dataframe(tmpdir):
     tree = MongoAdapter.from_mongomock(tmpdir)
 
     client = from_tree(
-        tree, api_key=API_KEY, authentication={"single_user_api_key": API_KEY}
+        tree, api_key=API_KEY, authentication={"single_user_api_key": API_KEY},
+        validation_registry=validation_registry,
     )
 
     dummy_array = numpy.ones((5, 7))
@@ -100,7 +107,8 @@ def test_queries(tmpdir):
     tree = MongoAdapter.from_mongomock(tmpdir)
 
     client = from_tree(
-        tree, api_key=API_KEY, authentication={"single_user_api_key": API_KEY}
+        tree, api_key=API_KEY, authentication={"single_user_api_key": API_KEY},
+        validation_registry=validation_registry,
     )
 
     keys = list(string.ascii_lowercase)
@@ -152,7 +160,8 @@ def test_delete(tmpdir):
 
     tree = MongoAdapter.from_mongomock(tmpdir)
     client = from_tree(
-        tree, api_key=API_KEY, authentication={"single_user_api_key": API_KEY}
+        tree, api_key=API_KEY, authentication={"single_user_api_key": API_KEY},
+        validation_registry=validation_registry,
     )
 
     # For dataframes
@@ -198,7 +207,8 @@ def test_write_array_chunked(tmpdir):
 
     tree = MongoAdapter.from_mongomock(tmpdir)
     client = from_tree(
-        tree, api_key=API_KEY, authentication={"single_user_api_key": API_KEY}
+        tree, api_key=API_KEY, authentication={"single_user_api_key": API_KEY},
+        validation_registry=validation_registry,
     )
 
     a = dask.array.arange(24).reshape((4, 6)).rechunk((2, 3))
@@ -222,7 +232,8 @@ def test_write_dataframe_partitioned(tmpdir):
 
     tree = MongoAdapter.from_mongomock(tmpdir)
     client = from_tree(
-        tree, api_key=API_KEY, authentication={"single_user_api_key": API_KEY}
+        tree, api_key=API_KEY, authentication={"single_user_api_key": API_KEY},
+        validation_registry=validation_registry,
     )
 
     data = {f"Column{i}": (1 + i) * numpy.ones(10) for i in range(5)}
@@ -249,7 +260,8 @@ def test_write_sparse_full(tmpdir):
 
     tree = MongoAdapter.from_mongomock(tmpdir)
     client = from_tree(
-        tree, api_key=API_KEY, authentication={"single_user_api_key": API_KEY}
+        tree, api_key=API_KEY, authentication={"single_user_api_key": API_KEY},
+        validation_registry=validation_registry,
     )
 
     coo = sparse.COO(coords=[[0, 1], [2, 3]], data=[3.8, 4.0], shape=(4, 4))
@@ -280,7 +292,8 @@ def test_write_sparse_chunked(tmpdir):
 
     tree = MongoAdapter.from_mongomock(tmpdir)
     client = from_tree(
-        tree, api_key=API_KEY, authentication={"single_user_api_key": API_KEY}
+        tree, api_key=API_KEY, authentication={"single_user_api_key": API_KEY},
+        validation_registry=validation_registry,
     )
 
     metadata = {"scan_id": 1, "method": "A"}
@@ -318,7 +331,8 @@ def test_update_array_metadata(tmpdir):
     tree = MongoAdapter.from_mongomock(tmpdir)
 
     client = from_tree(
-        tree, api_key=API_KEY, authentication={"single_user_api_key": API_KEY}
+        tree, api_key=API_KEY, authentication={"single_user_api_key": API_KEY},
+        validation_registry=validation_registry,
     )
 
     # Update metadata in array client
@@ -375,7 +389,8 @@ def test_update_dataframe_metadata(tmpdir):
     tree = MongoAdapter.from_mongomock(tmpdir)
 
     client = from_tree(
-        tree, api_key=API_KEY, authentication={"single_user_api_key": API_KEY}
+        tree, api_key=API_KEY, authentication={"single_user_api_key": API_KEY},
+        validation_registry=validation_registry,
     )
 
     test_array = numpy.ones((5, 5))

--- a/requirements-client.txt
+++ b/requirements-client.txt
@@ -1,3 +1,3 @@
 mongoquery
 msgpack >=1.0.0
-tiled[client] >=0.1.0a74
+tiled[client] >=0.1.0a75

--- a/requirements-server.txt
+++ b/requirements-server.txt
@@ -10,7 +10,7 @@ pydantic
 pymongo
 pytz
 starlette
-tiled[server] >=0.1.0a74
+tiled[server] >=0.1.0a75
 toolz
 tzlocal
 zarr

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -16,6 +16,6 @@ sphinx
 suitcase-jsonl >=0.1.0b2
 suitcase-mongo >=0.1.0
 suitcase-msgpack >=0.2.2
-tiled[all] >=0.1.0a74
+tiled[all] >=0.1.0a75
 ujson
 vcrpy


### PR DESCRIPTION
This PR implements a new approach in the use of references as an additional field in the document. It's use is similar to what we are doing with specs as a list of strings but references will consist in a list of `ReferenceDocument` object that can store a label and a url. The `references` object does not sit inside `metadata`; it seems more appropriate to leave it at the same level of `metadata` and `specs`
