### PR TITLE
Add CLI with shape-fixer.

### DIFF
--- a/databroker/cli.py
+++ b/databroker/cli.py
@@ -85,5 +85,8 @@ def shape_fix(
             progress.update(task, advance=1)
 
 
+main = cli_app
+
+
 if __name__ == "__main__":
-    cli_app()
+    main()

--- a/databroker/cli.py
+++ b/databroker/cli.py
@@ -54,14 +54,14 @@ def shape_fix(
 
     items = adapter.items()
     if limit:
-        typer.echo(f"Limited to first {limit} only")
+        typer.echo(f"Limited to first {limit} BlueskyRuns only")
         items = items[:limit]
 
     with Progress() as progress:
         task = progress.add_task("Migrating...", total=len(items))
         for uid, run in items:
             try:
-                for stream in run.values():
+                for stream_name, stream in run.items():
                     descriptor = stream.metadata["descriptors"][0]
                     recorded_shapes, measured_shapes = measure(
                         mds_database,
@@ -77,7 +77,7 @@ def shape_fix(
                         msg = "Edited"
                         fix(mds_database, descriptor, measured_shapes)
                     if recorded_shapes != measured_shapes:
-                        progress.console.print(f"{msg} {uid}: {recorded_shapes} -> {measured_shapes}")
+                        progress.console.print(f"{msg} {uid} {stream_name}: {recorded_shapes} -> {measured_shapes}")
             except Exception as exc:
                 if strict:
                     raise

--- a/databroker/cli.py
+++ b/databroker/cli.py
@@ -1,0 +1,89 @@
+from typing import List, Optional, Tuple
+
+import typer
+
+from tiled.utils import import_object
+from rich.progress import Progress
+import databroker.queries
+from databroker.mongo_normalized import MongoAdapter, discover_handlers
+
+
+from .shape_fixer import measure, fix
+
+
+cli_app = typer.Typer()
+admin_app = typer.Typer()
+cli_app.add_typer(
+    admin_app,
+    name="admin",
+    help="Administrative utilities for managing databroker.",
+)
+
+
+@admin_app.command("shape-fixer")
+def shape_fix(
+    uri: str,
+    asset_registry_uri: Optional[str] = None,
+    query: List[str] = [],
+    patch_resource: Optional[str] = None,
+    strict: bool = False,
+    dry_run: bool = False,
+    limit: Optional[int] = None,
+    handler: Optional[List[str]] = typer.Option(None, help="Handler given as 'SPEC = import_path'")
+):
+    if handler is None:
+        handler_registry = databroker.mongo_normalized.discover_handlers()
+    else:
+        handler_registry = {}
+        for h in handler:
+            if " = " not in h:
+                raise ValueError("Handler must be given as 'SPEC = import_path' (spaces matter)")
+            k, _, v = h.partition(" = ")
+            handler_registry[k] = import_object(v)
+    adapter = MongoAdapter.from_uri(uri, asset_registry_uri=asset_registry_uri)
+    mds_database = adapter._metadatastore_db
+    asset_database = adapter._asset_registry_db
+    if patch_resource is not None:
+        patch_resource = import_object(patch_resource)
+    if dry_run:
+        typer.echo("Dry run!")
+    for q in query:
+        parsed_query = eval(q, vars(databroker.queries))
+        adapter = adapter.search(parsed_query)
+    typer.echo(f"Migrating {adapter}")
+
+    items = adapter.items()
+    if limit:
+        typer.echo(f"Limited to first {limit} only")
+        items = items[:limit]
+
+    with Progress() as progress:
+        task = progress.add_task("Migrating...", total=len(items))
+        for uid, run in items:
+            try:
+                for stream in run.values():
+                    descriptor = stream.metadata["descriptors"][0]
+                    recorded_shapes, measured_shapes = measure(
+                        mds_database,
+                        asset_database,
+                        descriptor,
+                        adapter.root_map,
+                        handler_registry,
+                        patch_resource=patch_resource,
+                    )
+                    if dry_run:
+                        msg = "Dry run"
+                    else:
+                        msg = "Edited"
+                        fix(mds_database, descriptor, measured_shapes)
+                    if recorded_shapes != measured_shapes:
+                        progress.console.print(f"{msg} {uid}: {recorded_shapes} -> {measured_shapes}")
+            except Exception as exc:
+                if strict:
+                    raise
+                progress.console.print(f"Failed: {uid} {exc!r} (Use --strict for more.)")
+            progress.update(task, advance=1)
+
+
+if __name__ == "__main__":
+    cli_app()

--- a/databroker/cli.py
+++ b/databroker/cli.py
@@ -24,7 +24,9 @@ def shape_fix(
     strict: bool = False,
     dry_run: bool = False,
     limit: Optional[int] = None,
-    handler: Optional[List[str]] = typer.Option(None, help="Handler given as 'SPEC = import_path'")
+    handler: Optional[List[str]] = typer.Option(
+        None, help="Handler given as 'SPEC = import_path'"
+    ),
 ):
     """
     Fix shape metadata in Event Descriptors.
@@ -33,15 +35,17 @@ def shape_fix(
     import databroker.queries
     from databroker.mongo_normalized import MongoAdapter, discover_handlers
 
-
     from .shape_fixer import measure, fix
+
     if handler is None:
         handler_registry = discover_handlers()
     else:
         handler_registry = {}
         for h in handler:
             if " = " not in h:
-                raise ValueError("Handler must be given as 'SPEC = import_path' (spaces matter)")
+                raise ValueError(
+                    "Handler must be given as 'SPEC = import_path' (spaces matter)"
+                )
             k, _, v = h.partition(" = ")
             handler_registry[k] = import_object(v)
     adapter = MongoAdapter.from_uri(uri, asset_registry_uri=asset_registry_uri)
@@ -81,11 +85,15 @@ def shape_fix(
                         msg = "Edited"
                         fix(mds_database, descriptor, measured_shapes)
                     if recorded_shapes != measured_shapes:
-                        progress.console.print(f"{msg} {uid} {stream_name}: {recorded_shapes} -> {measured_shapes}")
+                        progress.console.print(
+                            f"{msg} {uid} {stream_name}: {recorded_shapes} -> {measured_shapes}"
+                        )
             except Exception as exc:
                 if strict:
                     raise
-                progress.console.print(f"Failed: {uid} {exc!r} (Use --strict for more.)")
+                progress.console.print(
+                    f"Failed: {uid} {exc!r} (Use --strict for more.)"
+                )
             progress.update(task, advance=1)
 
 

--- a/databroker/cli.py
+++ b/databroker/cli.py
@@ -1,4 +1,4 @@
-from typing import List, Optional, Tuple
+from typing import List, Optional
 
 import typer
 
@@ -32,7 +32,7 @@ def shape_fix(
     handler: Optional[List[str]] = typer.Option(None, help="Handler given as 'SPEC = import_path'")
 ):
     if handler is None:
-        handler_registry = databroker.mongo_normalized.discover_handlers()
+        handler_registry = discover_handlers()
     else:
         handler_registry = {}
         for h in handler:

--- a/databroker/cli.py
+++ b/databroker/cli.py
@@ -4,11 +4,6 @@ import typer
 
 from tiled.utils import import_object
 from rich.progress import Progress
-import databroker.queries
-from databroker.mongo_normalized import MongoAdapter, discover_handlers
-
-
-from .shape_fixer import measure, fix
 
 
 cli_app = typer.Typer()
@@ -31,6 +26,15 @@ def shape_fix(
     limit: Optional[int] = None,
     handler: Optional[List[str]] = typer.Option(None, help="Handler given as 'SPEC = import_path'")
 ):
+    """
+    Fix shape metadata in Event Descriptors.
+    """
+    # Imports are here to avoid making CLI slow.
+    import databroker.queries
+    from databroker.mongo_normalized import MongoAdapter, discover_handlers
+
+
+    from .shape_fixer import measure, fix
     if handler is None:
         handler_registry = discover_handlers()
     else:

--- a/databroker/shape_fixer.py
+++ b/databroker/shape_fixer.py
@@ -1,0 +1,61 @@
+"""
+Given a Run, fill one Event from each stream, measure its shape, and patch the
+Descriptors in that stream.
+"""
+import databroker.queries
+from event_model import Filler
+
+
+def log(*args, logfile, progress):
+    progress.write(" ".join([str(arg) for arg in args]))
+    print(*args, file=logfile, flush=True)
+
+
+def measure(mds_database, asset_database, descriptor, root_map, handler_registry, patch_resource=None):
+    """
+    Return {data_key: correct shape} for all external data_keys
+    """
+    recorded_shapes = {}
+    for key, data_key in descriptor["data_keys"].items():
+        if data_key.get("external"):
+            recorded_shapes[key] = data_key["shape"]
+    if not recorded_shapes:
+        # No external data, nothing to measure
+        return {}, {}
+    filler = Filler(handler_registry=handler_registry, inplace=False, root_map=root_map)
+    datum_collection = asset_database["datum"]
+    resource_collection = asset_database["resource"]
+    cursor = mds_database["event"].find(
+        {"descriptor": descriptor["uid"]}, sort=[("time", 1)]
+    )
+    try:
+        event = next(cursor)
+        event["filled"] = {key: False for key in recorded_shapes}
+    except StopIteration:
+        # No Events, nothing to measure
+        return {}, {}
+    filler("descriptor", descriptor)
+    resources = set()
+    measured_shapes = {}
+    for key in recorded_shapes:
+        datum = datum_collection.find_one({"datum_id": event["data"][key]})
+        if datum["resource"] not in resources:
+            resource = resource_collection.find_one({"uid": datum["resource"]})
+            if patch_resource is not None:
+                resource = patch_resource(resource)
+            filler("resource", resource)
+        filler("datum", datum)
+    _, filled_event = filler("event", event)
+    for key in recorded_shapes:
+        data = filled_event["data"][key]
+        measured_shapes[key] = [int(dim) for dim in data.shape]
+    return recorded_shapes, measured_shapes
+
+
+def fix(mds_database, descriptor, measured_shapes):
+    for key, measured_shape in measured_shapes.items():
+        mds_database["event_descriptor"].update_one(
+            {"uid": descriptor["uid"]},
+            {"$set": {f"data_keys.{key}.shape": measured_shape}},
+            upsert=False,
+        )

--- a/databroker/shape_fixer.py
+++ b/databroker/shape_fixer.py
@@ -10,7 +10,14 @@ def log(*args, logfile, progress):
     print(*args, file=logfile, flush=True)
 
 
-def measure(mds_database, asset_database, descriptor, root_map, handler_registry, patch_resource=None):
+def measure(
+    mds_database,
+    asset_database,
+    descriptor,
+    root_map,
+    handler_registry,
+    patch_resource=None,
+):
     """
     Return {data_key: correct shape} for all external data_keys
     """

--- a/databroker/shape_fixer.py
+++ b/databroker/shape_fixer.py
@@ -2,7 +2,6 @@
 Given a Run, fill one Event from each stream, measure its shape, and patch the
 Descriptors in that stream.
 """
-import databroker.queries
 from event_model import Filler
 
 

--- a/requirements-server.txt
+++ b/requirements-server.txt
@@ -9,8 +9,10 @@ pims
 pydantic
 pymongo
 pytz
+rich
 starlette
 tiled[server] >=0.1.0a74
 toolz
+typer
 tzlocal
 zarr

--- a/setup.py
+++ b/setup.py
@@ -68,6 +68,7 @@ setup(
     extras_require=extras_require,
     python_requires='>={}'.format('.'.join(str(n) for n in min_version)),
     entry_points={
+        "console_scripts": ["databroker = databroker.cli:main"],
         "tiled.special_client": [
             "CatalogOfBlueskyRuns = databroker.client:CatalogOfBlueskyRuns",
             "BlueskyRun = databroker.client:BlueskyRun",


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

This adds a CLI to databroker. In this PR it only has one command, but it is expected to grow more.

## Motivation and Context

This captures [the "shape-fixer"](https://github.com/danielballan/migration/blob/main/shape_fixer.py) which we use to retroactively edit the `shape` in the EventDescriptor to match the actual shape. This is intended to make it easily usable by people other than me. :-)

## How Has This Been Tested?

The shape-fixer has been used on about ten beamlines. This exact PR branch was run at ISS today.

<!--
## Screenshots (if appropriate):
-->
