### PR TITLE
Adjust for API change in tiled.

### DIFF
--- a/databroker/client.py
+++ b/databroker/client.py
@@ -4,7 +4,7 @@ import warnings
 
 import msgpack
 from tiled.adapters.utils import IndexCallable
-from tiled.client.node import Node
+from tiled.client.node import DEFAULT_STRUCTURE_CLIENT_DISPATCH, Node
 from tiled.client.utils import handle_error
 
 from .common import BlueskyEventStreamMixin, BlueskyRunMixin, CatalogOfBlueskyRunsMixin
@@ -207,7 +207,7 @@ and then read() will return dask objects.""",
             stacklevel=2,
         )
         return self.new_variation(
-            structure_clients=Node.DEFAULT_STRUCTURE_CLIENT_DISPATCH["dask"]
+            structure_clients=DEFAULT_STRUCTURE_CLIENT_DISPATCH["dask"]
         ).read()
 
 


### PR DESCRIPTION
Breakage was in https://github.com/bluesky/tiled/commit/eb4700bbf3c30bfcde4088bf499c3901524099ad, first released in v0.1.0a76. Detected by CHX beamline staff.