### PR TITLE
Include 'back-compat' deps in image.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,7 +17,7 @@ RUN pip install --upgrade --no-cache-dir -r /code/requirements-server.txt
 
 COPY . .
 # note requirements listed here but all deps should be already satisfied
-RUN pip install .[server]
+RUN pip install .[back-compat,server]
 
 FROM base as runner
 


### PR DESCRIPTION
I discovered while deploying at NSLS2 a couple weeks ago that one or more of these (at least `humanize`) is imported by the server. Not sure it _should_ be but for now I'd like to just fix the image in the most direct way possible.