### PR TITLE
Restore Broker.named('temp') in v2.

### DIFF
--- a/databroker/tests/test_config.py
+++ b/databroker/tests/test_config.py
@@ -10,7 +10,7 @@ import yaml
 from bluesky.plans import count
 from databroker.utils import ensure_path_exists
 from databroker.tests.utils import get_uids
-from databroker import (lookup_config, list_configs, describe_configs)
+from databroker import (lookup_config, list_configs, describe_configs, temp)
 from databroker.v0 import Broker, temp_config
 
 
@@ -103,3 +103,9 @@ def test_uri(RE, hw):
 
     config['api_version'] = 0
     broker = Broker.from_config(config)
+
+
+def test_temp():
+    # Two ways of getting a temporary Broker (backed by mongomock)
+    Broker.named("temp")
+    temp()

--- a/databroker/v1.py
+++ b/databroker/v1.py
@@ -210,7 +210,7 @@ class Broker:
                 "from the client."
             )
         if name == "temp":
-            raise NotImplementedError("databroker 2.0.0 does not yet support 'temp' Broker")
+            return temp()
         client = from_profile(name)
         if try_raw:
             try:


### PR DESCRIPTION
`Broker.named('temp')` is a convenience for making a Broker backed by an in-memory store. We disabled it when we were drafting v2 (raised `NotImplementedError`) but now we should restore it.