### PR TITLE
Test access policy on experimental adapter.

### DIFF
--- a/databroker/tests/conftest.py
+++ b/databroker/tests/conftest.py
@@ -1,3 +1,5 @@
+import contextlib
+import getpass
 import os
 import pytest
 import sys
@@ -114,3 +116,22 @@ SIM_DETECTORS = {'scalar': 'det',
 @pytest.fixture(params=['scalar', 'image', 'external_image'])
 def detector(request, hw):
     return getattr(hw, SIM_DETECTORS[request.param])
+
+
+@pytest.fixture
+def enter_password(monkeypatch):
+    """
+    Return a context manager that overrides getpass, used like:
+
+    >>> with enter_password(...):
+    ...     # Run code that calls getpass.getpass().
+    """
+
+    @contextlib.contextmanager
+    def f(password):
+        original = getpass.getpass
+        monkeypatch.setattr("getpass.getpass", lambda: password)
+        yield
+        monkeypatch.setattr("getpass.getpass", original)
+
+    return f

--- a/databroker/tests/test_access_policy.py
+++ b/databroker/tests/test_access_policy.py
@@ -1,32 +1,9 @@
-import contextlib
-import getpass
-
 from bluesky import RunEngine
 from bluesky.plans import count
-import pytest
 from tiled.client import Context, from_context
 from tiled.server.app import build_app_from_config
 
 from ..mongo_normalized import MongoAdapter, SimpleAccessPolicy
-
-
-@pytest.fixture
-def enter_password(monkeypatch):
-    """
-    Return a context manager that overrides getpass, used like:
-
-    >>> with enter_password(...):
-    ...     # Run code that calls getpass.getpass().
-    """
-
-    @contextlib.contextmanager
-    def f(password):
-        original = getpass.getpass
-        monkeypatch.setattr("getpass.getpass", lambda: password)
-        yield
-        monkeypatch.setattr("getpass.getpass", original)
-
-    return f
 
 
 def test_access_policy_pass_through():


### PR DESCRIPTION
This experimental adapter draft is on track to be superseded by work upstream in Tiled, but as we're still using it as a sandbox in places, I here fix its compatible with `tiled.access_policies.SimpleAccessPolicy`.