### PR TITLE
Add v2 accessors.

### DIFF
--- a/databroker/client.py
+++ b/databroker/client.py
@@ -55,6 +55,10 @@ class BlueskyRun(BlueskyRunMixin, Node):
         """
         return self.metadata["stop"]
 
+    @property
+    def v2(self):
+        return self
+
     def documents(self, fill=False):
         # For back-compat with v2:
         if fill == "yes":
@@ -228,6 +232,10 @@ class CatalogOfBlueskyRuns(CatalogOfBlueskyRunsMixin, Node):
         self.scan_id = IndexCallable(self._lookup_by_scan_id)
         self.uid = IndexCallable(self._lookup_by_partial_uid)
         self._v1 = None
+
+    @property
+    def v2(self):
+        return self
 
     def __getitem__(self, key):
         # For convenience and backward-compatiblity reasons, we support


### PR DESCRIPTION
The use case is to write functions that work on old-style `databroker.Header` and new-style `databroker.BlueskyRun`:

```py
In [3]: def f(header):
   ...:     "Accept databroker-style or tiled-style Header/BlueskyRun."
   ...:     run = header.v2  # works if header is already a tiled BlueskyRun or if it is a databroker Header
   ...:     return run['primary']['data']['fccd_image']
   ...: 

In [4]: from tiled.client import from_profile

In [5]: c = from_profile("csx")
OBJECT CACHE: Will use up to 20_214_985_728 bytes (15% of total physical RAM)

In [6]: run = c.values().last()

In [7]: f(run)
Out[7]: <ArrayClient shape=(5, 1, 1000, 960) chunks=((5,), (1,), (1000,), (960,)) dtype=int16 dims=('time', 'dim_0', 'dim_1', 'dim_2')>

In [8]: from databroker import Broker

In [9]: db = Broker.named("csx")
OBJECT CACHE: Will use up to 20_214_985_728 bytes (15% of total physical RAM)

In [10]: f(db[-1])
Out[10]: <ArrayClient shape=(5, 1, 1000, 960) chunks=((5,), (1,), (1000,), (960,)) dtype=int16 dims=('time', 'dim_0', 'dim_1', 'dim_2')>
```