### PR TITLE
Bump tiled version in image.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ghcr.io/bluesky/tiled:v0.1.0a89 as base
+FROM ghcr.io/bluesky/tiled:v0.1.0a92 as base
 
 FROM base as builder
 


### PR DESCRIPTION
Bump the tiled version. No specific motivation, just keeping the image current.

I also removed the vestigial `docker/` directory. (We now keep the `Dockerfile` in the repo root, and have for some time.)