### PR TITLE
Improve error message.

### DIFF
--- a/databroker/queries.py
+++ b/databroker/queries.py
@@ -413,7 +413,7 @@ def partial_uid(query, catalog):
     for partial_uid in query.partial_uids:
         if len(partial_uid) < 5:
             raise QueryValueError(
-                f"Partial uid {partial_uid} is too short. "
+                f"Partial uid {partial_uid!r} is too short. "
                 "It must include at least 5 characters."
             )
         result = catalog.apply_mongo_query({"uid": {"$regex": f"^{partial_uid}"}})


### PR DESCRIPTION
If someone does

```py
catalog["uid"]  # "uid" a literal string
```

where they meant

```py
catalog[uid]  # uid a variable
```

the error message is

```
Partial uid uid is too short. It must include at least 5 characters.
```

We want

```
Partial uid 'uid' is too short. It must include at least 5 characters.
```