### PR TITLE
Adjust for API change in Tiled

### DIFF
--- a/databroker/client.py
+++ b/databroker/client.py
@@ -4,7 +4,7 @@ import warnings
 
 import msgpack
 from tiled.adapters.utils import IndexCallable
-from tiled.client.node import DEFAULT_STRUCTURE_CLIENT_DISPATCH, Node
+from tiled.client.container import DEFAULT_STRUCTURE_CLIENT_DISPATCH, Container
 from tiled.client.utils import handle_error
 from tiled.utils import safe_json_dump
 
@@ -28,11 +28,11 @@ _document_types = {
 _IPYTHON_METHODS = {"_ipython_canary_method_should_not_exist_", "_repr_mimebundle_"}
 
 
-class BlueskyRun(BlueskyRunMixin, Node):
+class BlueskyRun(BlueskyRunMixin, Container):
     """
     This encapsulates the data and metadata for one Bluesky 'run'.
 
-    This adds for bluesky-specific conveniences to the standard client Node.
+    This adds for bluesky-specific conveniences to the standard client Container.
     """
 
     @property
@@ -70,7 +70,7 @@ class BlueskyRun(BlueskyRunMixin, Node):
         else:
             fill = bool(fill)
         link = self.item["links"]["self"].replace(
-            "/node/metadata", "/documents", 1
+            "/metadata", "/documents", 1
         )
         request = self.context.http_client.build_request(
             "GET",
@@ -142,11 +142,11 @@ class BlueskyRun(BlueskyRunMixin, Node):
     to_dask = read
 
 
-class BlueskyEventStream(BlueskyEventStreamMixin, Node):
+class BlueskyEventStream(BlueskyEventStreamMixin, Container):
     """
     This encapsulates the data and metadata for one 'stream' in a Bluesky 'run'.
 
-    This adds for bluesky-specific conveniences to the standard client Node.
+    This adds for bluesky-specific conveniences to the standard client Container.
     """
 
     @property
@@ -216,9 +216,9 @@ and then read() will return dask objects.""",
         ).read()
 
 
-class CatalogOfBlueskyRuns(CatalogOfBlueskyRunsMixin, Node):
+class CatalogOfBlueskyRuns(CatalogOfBlueskyRunsMixin, Container):
     """
-    This adds some bluesky-specific conveniences to the standard client Node.
+    This adds some bluesky-specific conveniences to the standard client Container.
 
     >>> catalog.scan_id[1234]  # scan_id lookup
     >>> catalog.uid["9acjef"]  # (partial) uid lookup
@@ -317,7 +317,7 @@ class CatalogOfBlueskyRuns(CatalogOfBlueskyRunsMixin, Node):
 
     def post_document(self, name, doc):
         link = self.item["links"]["self"].replace(
-            "/node/metadata", "/documents", 1
+            "/metadata", "/documents", 1
         )
         response = self.context.http_client.post(
             link,

--- a/databroker/client.py
+++ b/databroker/client.py
@@ -321,6 +321,6 @@ class CatalogOfBlueskyRuns(CatalogOfBlueskyRunsMixin, Container):
         )
         response = self.context.http_client.post(
             link,
-            data=safe_json_dump({"name": name, "doc": doc})
+            content=safe_json_dump({"name": name, "doc": doc})
         )
         handle_error(response)

--- a/databroker/mongo_normalized.py
+++ b/databroker/mongo_normalized.py
@@ -510,7 +510,7 @@ class DatasetFromDocuments:
     An xarray.Dataset from a sub-dict of an Event stream
     """
 
-    structure_family = "node"
+    structure_family = StructureFamily.container
     specs = [Spec("xarray_dataset")]
 
     def __init__(
@@ -1033,7 +1033,7 @@ def build_config_xarray(
 
 
 class MongoAdapter(collections.abc.Mapping, CatalogOfBlueskyRunsMixin, IndexersMixin):
-    structure_family = "node"
+    structure_family = StructureFamily.container
     specs = [Spec("CatalogOfBlueskyRuns", version="1")]
 
     # Define classmethods for managing what queries this MongoAdapter knows.
@@ -1664,7 +1664,7 @@ class MongoAdapter(collections.abc.Mapping, CatalogOfBlueskyRunsMixin, IndexersM
 
         if structure_families:
             distinct_structure_families = {
-                "value": StructureFamily.node,
+                "value": StructureFamily.container,
                 "count": node_size,
             }
             data["structure_families"] = [distinct_structure_families]

--- a/databroker/tests/test_queries.py
+++ b/databroker/tests/test_queries.py
@@ -161,7 +161,7 @@ def test_distinct(c, RE, hw):
         "metadata": {
             "start.foo": [{"value": "a", "count": 1}, {"value": "b", "count": 1}]
         },
-        "structure_families": [{"value": "node", "count": 2}],
+        "structure_families": [{"value": "container", "count": 2}],
         "specs": [{"value": [{"name": "BlueskyRun", "version": "1"}], "count": 2}],
     }
 

--- a/requirements-client.txt
+++ b/requirements-client.txt
@@ -1,4 +1,4 @@
 mongoquery
 msgpack >=1.0.0
 orjson
-tiled[client] >=0.1.0a89
+tiled[client] >=0.1.0a98

--- a/requirements-server.txt
+++ b/requirements-server.txt
@@ -13,7 +13,7 @@ pytz
 rich
 starlette
 suitcase-mongo
-tiled[server] >=0.1.0a89
+tiled[server] >=0.1.0a98
 toolz
 typer
 tzlocal

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -16,6 +16,6 @@ sphinx
 suitcase-jsonl >=0.1.0b2
 suitcase-mongo >=0.1.0
 suitcase-msgpack >=0.2.2
-tiled[all] >=0.1.0a89
+tiled[all] >=0.1.0a98
 ujson
 vcrpy


### PR DESCRIPTION
Tiled is renaming the structure family `node` to `container`. The term "node" will now be used to refer to _any_ item in Tiled's data model, be it an array, dataframe, container, etc. https://github.com/bluesky/tiled/pull/478

This PR adjusts for that. The tests will not pass until Tiled is next released.