### PR TITLE
Test string column

### DIFF
--- a/databroker/mongo_normalized.py
+++ b/databroker/mongo_normalized.py
@@ -549,7 +549,7 @@ class DatasetFromDocuments:
             for key, field_metadata in descriptor["data_keys"].items():
                 if field_metadata["dtype"] == "string":
                     # Skip this if it has a dtype_str with an itemsize.
-                    dtype_str = field_metadata().get("dtype_str")
+                    dtype_str = field_metadata.get("dtype_str")
                     if dtype_str is not None:
                         if numpy.dtype(dtype_str).itemsize != 0:
                             continue

--- a/databroker/tests/test_broker.py
+++ b/databroker/tests/test_broker.py
@@ -1168,3 +1168,23 @@ def test_v2_accessor(db, RE, hw):
     assert db.v2[uid].start["uid"] == h.start["uid"]
     # v2-style CatalogOfBlueskyRuns has v2 accessor
     assert db.v2.v2.v2[uid].start["uid"] == h.start["uid"]
+
+
+def test_string_column(db, RE, hw):
+    "Test string data."
+    from ophyd.sim import EnumSignal
+
+
+    class StringSignal(EnumSignal):
+        def describe(self):
+            desc = super().describe()
+            desc[self.name]["dtype"] = "string"
+            return desc
+
+    if not hasattr(db, "v2"):
+        raise pytest.skip("v0 has no v2 accessor")
+
+    RE.subscribe(db.insert)
+    signal = StringSignal(value="A", enum_strings=("A", "B"), name="signal")
+    uid, = get_uids(RE(count([signal], 5)))
+    data = db.v2[uid]["primary"]["data"]


### PR DESCRIPTION
This fixes a bug that was reported as an issue with `baseline` readings. The underlying problem was with string columns, which happened to appear in the `baseline` stream in this instance. It was a two-character fix for a bug introduced 3 weeks ago, in #781.

A unit test reproduces the bug in the first commit, and the second commit fixes the bug.