### PR TITLE
Fix compat with tiled API changes.

### DIFF
--- a/databroker/assets/tests/test_mongo_details.py
+++ b/databroker/assets/tests/test_mongo_details.py
@@ -12,16 +12,6 @@ def test_double_sentinel(fs_mongo):
         install_sentinels(fs.config, fs.version)
 
 
-def test_index(fs_mongo):
-    fs = fs_mongo
-    fs._create_datum_index()
-    indx = fs._datum_col.index_information()
-
-    assert len(indx) == 3
-    index_fields = set(v['key'][0][0] for v in indx.values())
-    assert index_fields == {'_id', 'datum_id', 'resource'}
-
-
 def test_reconfigure(fs_mongo):
     fs = fs_mongo
     fs.reconfigure(fs.config)

--- a/databroker/mongo_normalized.py
+++ b/databroker/mongo_normalized.py
@@ -652,14 +652,10 @@ class DatasetFromDocuments:
             specs = (
                 [Spec("xarray_coord")] if key == "time" else [Spec("xarray_data_var")]
             )
-            if isinstance(array, dask.array.Array):
-                constructor = ArrayAdapter
-            else:
-                constructor = ArrayAdapter.from_array
-            mapping[key] = constructor(
+            mapping[key] = ArrayAdapter(
                 array,
                 metadata=self.array_metadata[key],
-                dims=structure.dims,
+                structure=structure,
                 specs=specs,
             )
         return DatasetMapAdapter(mapping, metadata=self.metadata(), specs=self.specs)

--- a/databroker/mongo_normalized.py
+++ b/databroker/mongo_normalized.py
@@ -14,7 +14,6 @@ from bson.objectid import ObjectId, InvalidId
 import cachetools
 import entrypoints
 import event_model
-import dask.array
 from dask.array.core import cached_cumsum, normalize_chunks
 import numpy
 import pymongo

--- a/databroker/tests/utils.py
+++ b/databroker/tests/utils.py
@@ -119,4 +119,6 @@ def build_legacy_mongo_backed_broker(request):
 
     request.addfinalizer(delete_fs)
 
+    # Create indexes.
+    suitcase.mongo_normalized.Serializer(mds._db, fs._db)
     return v0.Broker(mds, fs)

--- a/requirements-server.txt
+++ b/requirements-server.txt
@@ -12,7 +12,7 @@ pymongo
 pytz
 rich
 starlette
-suitcase-mongo
+suitcase-mongo >=0.4.0
 tiled[server] >=0.1.0a105
 toolz
 typer

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -14,7 +14,7 @@ pytest >=4.4,!=5.4.0
 pytest-rerunfailures
 sphinx
 suitcase-jsonl >=0.1.0b2
-suitcase-mongo >=0.1.0
+suitcase-mongo >=0.4.0
 suitcase-msgpack >=0.2.2
 tiled[all] >=0.1.0a105
 ujson


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Update usage of `ArrayAdapter`.

## Motivation and Context

Tiled made backward-compatible changes in https://github.com/bluesky/tiled/pull/537. The databroker adapter was not fully updated to account for this. The issue went un-caught because it only occurs on a codepath where a databroker handler returns a Dask Array. This is not tested.

## How Has This Been Tested?

I tested this interactively by looking at two pieces of real beamline data:
* https://tiled-demo.blueskyproject.io/ui/browse/bmm/raw/5631b9e1-b07d-4455-ae85-36e9a84ab7dc/primary/data/I0
* https://tiled-demo.blueskyproject.io/ui/browse/fxi/raw/1b0b4d73-6d87-43ab-8d62-ed035c51b9b4/primary/data/Andor_image

...using current `main` (broken) and this PR branch (currently deployed, works).

There _should_ be a unit test but that would actually be a pretty big addition to the current Databroker test harness, and we are in a rush to land this before the resumption of operations.