### PR TITLE
Improve  JSON sequence deserialization using `newline` delimiter instead of `try except`

### DIFF
--- a/databroker/client.py
+++ b/databroker/client.py
@@ -81,14 +81,13 @@ class BlueskyRun(BlueskyRunMixin, Container):
                 handle_error(response)
             tail = ""
             for chunk in response.iter_bytes():
-                for line in chunk.decode().splitlines():
-                    try:
+                for line in chunk.decode().splitlines(keepends=True):
+                    if line[-1] == "\n":
                         item = json.loads(tail + line)
-                    except json.JSONDecodeError:
-                        tail += line
-                    else:
                         yield (item["name"], _document_types[item["name"]](item["doc"]))
                         tail = ""
+                    else:
+                        tail += line
 
     def __getattr__(self, key):
         """

--- a/databroker/client.py
+++ b/databroker/client.py
@@ -88,6 +88,9 @@ class BlueskyRun(BlueskyRunMixin, Container):
                         tail = ""
                     else:
                         tail += line
+            if tail:
+                item = json.loads(tail)
+                yield (item["name"], _document_types[item["name"]](item["doc"]))
 
     def __getattr__(self, key):
         """


### PR DESCRIPTION
This PR improves on #790  by using `newline` delimiter to check for the completeness of streamed JSON objects instead of catching `JSONDecodeError`.

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
The `splitline` method called on decoded chunks of streamed JSON sequences is passed the argument `keepends=True`. That way it preserves the `newline` character at the end of each split, if any. Checking for its existence is used as a more robust way of detecting a complete JSON object.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
If `JSONDecodeError` is raised for a legitimate reason the previous implementation would mask the exception and go on to do something it is not supposed to do by trying to mash together JSON objects incorrectly. A more robust implementation is to check for the presence of a `newline` delimiter to detect the end of a streamed serialized JSON object.

## How Has This Been Tested?
This change was tested using `pytest databroker/tests/test_broker.py::test_large_document`

<!--
## Screenshots (if appropriate):
-->