### PR TITLE
Fixed definition of xarray dimensionality during build configuration

### DIFF
--- a/databroker/mongo_normalized.py
+++ b/databroker/mongo_normalized.py
@@ -110,10 +110,13 @@ def structure_from_descriptor(descriptor, sub_dict, max_seq_num, unicode_columns
         # if the EventDescriptor doesn't provide names for the
         # dimensions (it's optional) use the same default dimension
         # names that xarray would.
-        try:
-            dims = ["time"] + field_metadata["dims"]
-        except KeyError:
-            ndim = len(field_metadata["shape"])
+        ndim = len(field_metadata["shape"])
+        if "dims" in field_metadata:
+            if len(field_metadata["dims"]) == ndim:
+                dims = ["time"] + field_metadata["dims"]
+            else:
+                dims = ["time"] + [f"dim_{next(dim_counter)}" for _ in range(ndim)]
+        else:
             dims = ["time"] + [f"dim_{next(dim_counter)}" for _ in range(ndim)]
         attrs = {}
         # Record which object (i.e. device) this column is associated with,
@@ -1005,10 +1008,13 @@ def build_config_xarray(
             # if the EventDescriptor doesn't provide names for the
             # dimensions (it's optional) use the same default dimension
             # names that xarray would.
-            try:
-                dims = ["time"] + field_metadata["dims"]
-            except KeyError:
-                ndim = len(field_metadata["shape"])
+            ndim = len(field_metadata["shape"])
+            if "dims" in field_metadata:
+                if len(field_metadata["dims"]) == ndim:
+                    dims = ["time"] + field_metadata["dims"]
+                else:
+                    dims = ["time"] + [f"dim_{next(dim_counter)}" for _ in range(ndim)]
+            else:
                 dims = ["time"] + [f"dim_{next(dim_counter)}" for _ in range(ndim)]
             units = field_metadata.get("units")
             if units:

--- a/databroker/mongo_normalized.py
+++ b/databroker/mongo_normalized.py
@@ -111,11 +111,8 @@ def structure_from_descriptor(descriptor, sub_dict, max_seq_num, unicode_columns
         # dimensions (it's optional) use the same default dimension
         # names that xarray would.
         ndim = len(field_metadata["shape"])
-        if "dims" in field_metadata:
-            if len(field_metadata["dims"]) == ndim:
-                dims = ["time"] + field_metadata["dims"]
-            else:
-                dims = ["time"] + [f"dim_{next(dim_counter)}" for _ in range(ndim)]
+        if "dims" in field_metadata and len(field_metadata["dims"]) == ndim:
+            dims = ["time"] + field_metadata["dims"]
         else:
             dims = ["time"] + [f"dim_{next(dim_counter)}" for _ in range(ndim)]
         attrs = {}
@@ -1009,11 +1006,8 @@ def build_config_xarray(
             # dimensions (it's optional) use the same default dimension
             # names that xarray would.
             ndim = len(field_metadata["shape"])
-            if "dims" in field_metadata:
-                if len(field_metadata["dims"]) == ndim:
-                    dims = ["time"] + field_metadata["dims"]
-                else:
-                    dims = ["time"] + [f"dim_{next(dim_counter)}" for _ in range(ndim)]
+            if "dims" in field_metadata and len(field_metadata["dims"]) == ndim:
+                dims = ["time"] + field_metadata["dims"]
             else:
                 dims = ["time"] + [f"dim_{next(dim_counter)}" for _ in range(ndim)]
             units = field_metadata.get("units")


### PR DESCRIPTION
This PR fixes an error identified while trying to read an array inside an xarray.Dataset with a dimension size greater that 2

## Description
This error was identified and tracked while trying to read some data from BlueSky runs for the Data Security project at SRX.

## Motivation and Context
It was identified that the` xs_flour` array was returning an error while data was requested through the `,read()` method in its parent node. This means that these two examples were failing:
```
c['srx']['raw'][152589]['stream0']['data'].read()
c['srx']['raw'][152589]['stream0']['data'].read('xs_fluor')
```
Initially, it was thought the problem was on the client side but the error was tracked all the way to the server side and it was identified that the error was being saved with the document at the moment this one was built.
It was also identified that part of this error is generated during the definition of some area detectors in a different repo (https://github.com/NSLS-II/nslsii/blob/master/nslsii/areadetector/xspress3.py#L139-L143)
The changes in this PR solve this conflict by making the definition of the xarray dimensions more robust but it is recommended to fix the original problem in this second repo.
