### PR TITLE
Support updating metadata from Tiled client 🧱

### DIFF
--- a/databroker/mongo_normalized.py
+++ b/databroker/mongo_normalized.py
@@ -276,18 +276,19 @@ class BlueskyRun(MapAdapter, BlueskyRunMixin):
     async def update_metadata(self, metadata=None, specs=None):
         if("start" not in metadata):
              raise NotImplementedError('update_metadata method not implemented')
-        elif(specs is not None):
+        elif(specs is None):
             raise NotImplementedError('Updating of specs is not yet supported.')
         start = metadata["start"]
-        # stop = metadata["stop"]
+        stop = metadata["stop"] if "stop" in metadata else None
         try:
             schema_validators[DocumentNames.start].validate(start)
-            # schema_validators[DocumentNames.stop].validate(stop)
+            if (stop is not None):
+                schema_validators[DocumentNames.stop].validate(stop)
         except ValidationError as err:
             raise
         # Update start
         self._serializer.update("start", metadata["start"])
-        # self._serializer.update("stop", metadata["stop"])
+        self._serializer.update("stop", metadata["stop"])
 
     @property
     def filler(self):

--- a/databroker/mongo_normalized.py
+++ b/databroker/mongo_normalized.py
@@ -257,6 +257,10 @@ class BlueskyRun(MapAdapter, BlueskyRunMixin):
         if self._metadata["stop"] is not None:
             return datetime.utcnow() + timedelta(hours=1)
 
+    @property
+    def key(self):
+        return self._metadata["start"]["uid"]
+
     def metadata(self):
         "Metadata about this MongoAdapter."
         # If there are transforms configured, shadow the 'start' and 'stop' documents

--- a/databroker/mongo_normalized.py
+++ b/databroker/mongo_normalized.py
@@ -471,10 +471,10 @@ class BlueskyEventStream(MapAdapter, BlueskyEventStreamMixin):
     
     async def update_metadata(self, metadata=None, specs=None):
         if("descriptors" not in metadata):
-             raise NotImplementedError('update_metadata method not implemented')
+             raise NotImplementedError('Update_metadata method requires descriptors.')
         # Update descriptors
         for descriptor in metadata["descriptors"]:
-            self.serializer.update("descriptor", descriptor)        # self._serializer.update("stop", metadata["stop"])
+            self.serializer.update("descriptor", descriptor)
         
 
     def new_variation(self, **kwargs):

--- a/databroker/mongo_normalized.py
+++ b/databroker/mongo_normalized.py
@@ -470,25 +470,11 @@ class BlueskyEventStream(MapAdapter, BlueskyEventStreamMixin):
         return metadata
     
     async def update_metadata(self, metadata=None, specs=None):
-        if("start" not in metadata):
+        if("descriptors" not in metadata):
              raise NotImplementedError('update_metadata method not implemented')
-        elif(specs is not None):
-            raise NotImplementedError('Updating of specs is not yet supported.')
-        start = metadata["start"]
-        # stop = metadata["stop"]
-        try:
-            schema_validators[DocumentNames.start].validate(start)
-            # schema_validators[DocumentNames.stop].validate(stop)
-        except ValidationError as err:
-            raise
-        # Update start
-        self._serializer.update("start", metadata["start"])
         # Update descriptors
-        # TODO: uncomment when support is added in suitcase mongo
-        # for descriptor in metadata["descriptors"]:
-        #     self.serializer.update("descriptor", descriptor)
-        # Update stop
-        # self._serializer.update("stop", metadata["stop"])
+        for descriptor in metadata["descriptors"]:
+            self.serializer.update("descriptor", descriptor)        # self._serializer.update("stop", metadata["stop"])
         
 
     def new_variation(self, **kwargs):

--- a/databroker/mongo_normalized.py
+++ b/databroker/mongo_normalized.py
@@ -261,6 +261,9 @@ class BlueskyRun(MapAdapter, BlueskyRunMixin):
             transformed["stop"] = self.transforms["stop"](self._metadata["stop"])
         metadata = dict(collections.ChainMap(transformed, self._metadata))
         return metadata
+    
+    async def update_metadata(self, metadata=None, specs=None):
+        raise NotImplementedError('update_metadata method not implemented')
 
     @property
     def filler(self):
@@ -440,6 +443,9 @@ class BlueskyEventStream(MapAdapter, BlueskyEventStreamMixin):
             ]
         metadata = dict(collections.ChainMap(transformed, self._metadata))
         return metadata
+    
+    async def update_metadata(self, metadata=None, specs=None):
+        raise NotImplementedError('update_metadata method not implemented')
 
     def new_variation(self, **kwargs):
         return super().new_variation(

--- a/databroker/mongo_normalized.py
+++ b/databroker/mongo_normalized.py
@@ -478,7 +478,7 @@ class BlueskyEventStream(MapAdapter, BlueskyEventStreamMixin):
         # Update descriptors
         for descriptor in metadata["descriptors"]:
             schema_validators[DocumentNames.descriptor].validate(descriptor)
-            self.serializer.update("descriptor", descriptor)
+            self._serializer.update("descriptor", descriptor)
         self._clear_from_cache()
 
     def new_variation(self, **kwargs):

--- a/databroker/mongo_normalized.py
+++ b/databroker/mongo_normalized.py
@@ -274,8 +274,10 @@ class BlueskyRun(MapAdapter, BlueskyRunMixin):
         return metadata
     
     async def update_metadata(self, metadata=None, specs=None):
-        # if(specs is not None or "start" not in metadata):
-        #     raise NotImplementedError('update_metadata method not implemented')
+        if("start" not in metadata):
+             raise NotImplementedError('update_metadata method not implemented')
+        elif(specs is not None):
+            raise NotImplementedError('Updating of specs is not yet supported.')
         start = metadata["start"]
         # stop = metadata["stop"]
         try:

--- a/databroker/mongo_normalized.py
+++ b/databroker/mongo_normalized.py
@@ -474,6 +474,10 @@ class BlueskyEventStream(MapAdapter, BlueskyEventStreamMixin):
              raise NotImplementedError('Update_metadata method requires descriptors.')
         # Update descriptors
         for descriptor in metadata["descriptors"]:
+            try:
+                schema_validators[DocumentNames.descriptor].validate(descriptor)
+            except ValidationError as err:
+                raise
             self.serializer.update("descriptor", descriptor)
         
 

--- a/databroker/mongo_normalized.py
+++ b/databroker/mongo_normalized.py
@@ -469,8 +469,10 @@ class BlueskyEventStream(MapAdapter, BlueskyEventStreamMixin):
         return metadata
     
     async def update_metadata(self, metadata=None, specs=None):
-        # if(specs is not None or "start" not in metadata):
-        #     raise NotImplementedError('update_metadata method not implemented')
+        if("start" not in metadata):
+             raise NotImplementedError('update_metadata method not implemented')
+        elif(specs is not None):
+            raise NotImplementedError('Updating of specs is not yet supported.')
         start = metadata["start"]
         # stop = metadata["stop"]
         try:
@@ -480,6 +482,11 @@ class BlueskyEventStream(MapAdapter, BlueskyEventStreamMixin):
             raise
         # Update start
         self._serializer.update("start", metadata["start"])
+        # Update descriptors
+        # TODO: uncomment when support is added in suitcase mongo
+        # for descriptor in metadata["descriptors"]:
+        #     self.serializer.update("descriptor", descriptor)
+        # Update stop
         # self._serializer.update("stop", metadata["stop"])
         
 


### PR DESCRIPTION
This adds the ability for the raw blueskyRun and BlueskyEventStream objects to update their metadata, putting the onus on clients that invoke it to preserve existing metadata. Currently behaves like a `PUT` request, overwriting the existing data unless the client performs a `copy.deepcopy()` of the extant metadata dict.

Here is the code for performing such an update, keep in mind that the client should now be refactored with friendlier facilities for performing this action including HTTP `PATCH` requests like `rfc6902`. Potentially this would manifest as 
- update_metadata (alias)
- patch_metadata
- put_metadata

```
import tiled
import copy
from tiled.client import from_uri
c = from_uri("http://localhost:8000",api_key="secret")
metadata = copy.deepcopy(dict(c[154705].metadata))
metadata["start"]["num_points"] = 2
c[154705].update_metadata(metadata=metadata)
```

Fix #792