### PR TITLE
Update dependencies to make tests pass

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,6 +37,9 @@ docs/_build
 pip-log.txt
 pip-delete-this-directory.txt
 
+# dotenv environment variables file
+.env*
+
 # Unit test / coverage reports
 htmlcov/
 .tox/

--- a/databroker/mongo_normalized.py
+++ b/databroker/mongo_normalized.py
@@ -643,6 +643,9 @@ class DatasetFromDocuments:
     def metadata(self):
         return self._metadata
 
+    def structure(self):
+        return None
+
     def keys(self):
         return self._contents.keys()
 
@@ -1417,6 +1420,9 @@ class MongoAdapter(collections.abc.Mapping, CatalogOfBlueskyRunsMixin, IndexersM
     def metadata(self):
         "Metadata about this MongoAdapter."
         return self._metadata
+
+    def structure(self):
+        return None
 
     @property
     def sorting(self):

--- a/databroker/tests/utils.py
+++ b/databroker/tests/utils.py
@@ -120,5 +120,6 @@ def build_legacy_mongo_backed_broker(request):
     request.addfinalizer(delete_fs)
 
     # Create indexes.
-    suitcase.mongo_normalized.Serializer(mds._db, fs._db)
+    serializer = suitcase.mongo_normalized.Serializer(mds._db, fs._db)
+    serializer.create_indexes()
     return v0.Broker(mds, fs)

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -3,6 +3,7 @@ bluesky
 codecov
 coverage
 flake8
+glue-core <1.18
 glueviz
 matplotlib
 mongomock


### PR DESCRIPTION
## Description
Tests are failing in GitHub CI and locally on my laptop.

### Updates
* [Create indexes for mongo-legacy backend](https://github.com/padraic-shafer/databroker/commit/81d9c6374b63314c9ad604f902c1306348304a59)
* [Pin glue-core to keep glue.qglue](https://github.com/padraic-shafer/databroker/commit/5be59a74906eeb2b8ac7d5bcdde1f25bfae0ce4f)
* [Add .structure() to mongo_normalized adapters](https://github.com/padraic-shafer/databroker/commit/995cc95c20879550a144beae7bbb4439ef5f61af)

### Bonus
* [Keep .env secrets out of project repo](https://github.com/padraic-shafer/databroker/commit/451e4239753568dde0646d1d3a89de303ef2f024) 

## Motivation and Context
Currently tests are failing; these changes enable test suite to pass without loss of functionality.

## How Has This Been Tested?
Tested locally on MacOS (M2) with fresh instances of Mongo:(5, 6, 7) available on port 27017 (pulled from official docker hub mongo images) and with tiled image from `databroker/docker-compose.yml`.

