### PR TITLE
Accept numpy.int64 as databroker catalog key

### DIFF
--- a/databroker/_core.py
+++ b/databroker/_core.py
@@ -24,7 +24,7 @@ import jinja2
 import time
 from .utils import (ALL, get_fields, wrap_in_deprecated_doct, wrap_in_doct,
                     DeprecatedDoct, DOCT_NAMES, lookup_config, list_configs,
-                    describe_configs, SPECIAL_NAME, ensure_int_key)
+                    describe_configs, SPECIAL_NAME)
 
 from databroker.assets.core import DatumNotFound, EventDatumNotFound
 
@@ -761,7 +761,7 @@ def _(key, db):
 @search.register(numbers.Integral)
 def _(key, db):
     logger.info('Interpreting key = %s as an integer' % key)
-    key = ensure_int_key(key)
+    key = int(key)
     if key > -1:
         # Interpret key as a scan_id.
         gen = db.hs.find_run_starts(scan_id=key)

--- a/databroker/_core.py
+++ b/databroker/_core.py
@@ -761,6 +761,16 @@ def _(key, db):
 @search.register(numbers.Integral)
 def _(key, db):
     logger.info('Interpreting key = %s as an integer' % key)
+    # Handle large values, such as numpy.int64
+    max_int_value = 2**31 - 1  ## 32-bit signed integer
+    if abs(key) <= max_int_value:
+        key = int(key)
+    else:
+        reason = " ".join(
+            f"Integer key must be less than +/-{max_int_value};",
+            f"cannot convert value {key} of type {type(key)}."
+        )
+        raise KeyError(reason)
     if key > -1:
         # Interpret key as a scan_id.
         gen = db.hs.find_run_starts(scan_id=key)

--- a/databroker/_core.py
+++ b/databroker/_core.py
@@ -24,7 +24,7 @@ import jinja2
 import time
 from .utils import (ALL, get_fields, wrap_in_deprecated_doct, wrap_in_doct,
                     DeprecatedDoct, DOCT_NAMES, lookup_config, list_configs,
-                    describe_configs, SPECIAL_NAME)
+                    describe_configs, SPECIAL_NAME, ensure_int_key)
 
 from databroker.assets.core import DatumNotFound, EventDatumNotFound
 
@@ -761,16 +761,7 @@ def _(key, db):
 @search.register(numbers.Integral)
 def _(key, db):
     logger.info('Interpreting key = %s as an integer' % key)
-    # Handle large values, such as numpy.int64
-    max_int_value = 2**31 - 1  ## 32-bit signed integer
-    if abs(key) <= max_int_value:
-        key = int(key)
-    else:
-        reason = " ".join((
-            f"Integer key must be less than +/-{max_int_value};",
-            f"cannot convert value {key} of type {type(key)}.",
-        ))
-        raise KeyError(reason)
+    key = ensure_int_key(key)
     if key > -1:
         # Interpret key as a scan_id.
         gen = db.hs.find_run_starts(scan_id=key)

--- a/databroker/_core.py
+++ b/databroker/_core.py
@@ -768,7 +768,7 @@ def _(key, db):
     else:
         reason = " ".join((
             f"Integer key must be less than +/-{max_int_value};",
-            f"cannot convert value {key} of type {type(key)}."
+            f"cannot convert value {key} of type {type(key)}.",
         ))
         raise KeyError(reason)
     if key > -1:

--- a/databroker/_core.py
+++ b/databroker/_core.py
@@ -766,10 +766,10 @@ def _(key, db):
     if abs(key) <= max_int_value:
         key = int(key)
     else:
-        reason = " ".join(
+        reason = " ".join((
             f"Integer key must be less than +/-{max_int_value};",
             f"cannot convert value {key} of type {type(key)}."
-        )
+        ))
         raise KeyError(reason)
     if key > -1:
         # Interpret key as a scan_id.

--- a/databroker/client.py
+++ b/databroker/client.py
@@ -12,7 +12,6 @@ from tiled.utils import safe_json_dump
 from .common import BlueskyEventStreamMixin, BlueskyRunMixin, CatalogOfBlueskyRunsMixin
 from .queries import PartialUID, RawMongo, ScanID
 from .document import Start, Stop, Descriptor, EventPage, DatumPage, Resource
-from .utils import ensure_int_key
 
 
 _document_types = {
@@ -260,7 +259,7 @@ class CatalogOfBlueskyRuns(CatalogOfBlueskyRunsMixin, Container):
             else:
                 # CASE 3: Interpret key as a recently lookup, as in
                 # `catalog[-1]` is the latest entry.
-                key = ensure_int_key(key)
+                key = int(key)
                 return self.values()[key]
         elif isinstance(key, slice):
             if (key.start is None) or (key.start >= 0):

--- a/databroker/client.py
+++ b/databroker/client.py
@@ -12,6 +12,7 @@ from tiled.utils import safe_json_dump
 from .common import BlueskyEventStreamMixin, BlueskyRunMixin, CatalogOfBlueskyRunsMixin
 from .queries import PartialUID, RawMongo, ScanID
 from .document import Start, Stop, Descriptor, EventPage, DatumPage, Resource
+from .utils import ensure_int_key
 
 
 _document_types = {
@@ -259,6 +260,7 @@ class CatalogOfBlueskyRuns(CatalogOfBlueskyRunsMixin, Container):
             else:
                 # CASE 3: Interpret key as a recently lookup, as in
                 # `catalog[-1]` is the latest entry.
+                key = ensure_int_key(key)
                 return self.values()[key]
         elif isinstance(key, slice):
             if (key.start is None) or (key.start >= 0):

--- a/databroker/client.py
+++ b/databroker/client.py
@@ -1,6 +1,7 @@
 import collections.abc
 import json
 import keyword
+import numbers
 import warnings
 
 from tiled.adapters.utils import IndexCallable
@@ -251,7 +252,17 @@ class CatalogOfBlueskyRuns(CatalogOfBlueskyRunsMixin, Container):
                     # Fall back to partial uid lookup below.
                     pass
             return self._lookup_by_partial_uid(key)
-        elif isinstance(key, int):
+        elif isinstance(key, numbers.Integral):
+            # Handle large values, such as numpy.int64
+            max_int_value = 2**31 - 1  ## 32-bit signed integer
+            if abs(key) <= max_int_value:
+                key = int(key)
+            else:
+                reason = " ".join(
+                    f"Integer key must be less than +/-{max_int_value};",
+                    f"cannot convert value {key} of type {type(key)}."
+                )
+                raise KeyError(reason)
             if key > 0:
                 # CASE 2: Interpret key as a scan_id.
                 return self._lookup_by_scan_id(key)

--- a/databroker/client.py
+++ b/databroker/client.py
@@ -253,16 +253,6 @@ class CatalogOfBlueskyRuns(CatalogOfBlueskyRunsMixin, Container):
                     pass
             return self._lookup_by_partial_uid(key)
         elif isinstance(key, numbers.Integral):
-            # Handle large values, such as numpy.int64
-            max_int_value = 2**31 - 1  ## 32-bit signed integer
-            if abs(key) <= max_int_value:
-                key = int(key)
-            else:
-                reason = " ".join(
-                    f"Integer key must be less than +/-{max_int_value};",
-                    f"cannot convert value {key} of type {type(key)}."
-                )
-                raise KeyError(reason)
             if key > 0:
                 # CASE 2: Interpret key as a scan_id.
                 return self._lookup_by_scan_id(key)

--- a/databroker/tests/test_broker.py
+++ b/databroker/tests/test_broker.py
@@ -261,6 +261,13 @@ def test_int64_indexing(db_empty, RE, hw):
     with does_not_raise():
         db[integer64_key]
 
+    # Key is Nth-last scan
+    integer64_key = np.int64(-1)
+    assert not isinstance(integer64_key, int)
+    assert isinstance(integer64_key, numbers.Integral)
+    with does_not_raise():
+        db[integer64_key]
+
     # Key is too large
     integer64_key = np.int64(2**33)
     assert not isinstance(integer64_key, int)

--- a/databroker/tests/test_broker.py
+++ b/databroker/tests/test_broker.py
@@ -279,7 +279,7 @@ def test_int64_indexing(db_empty, RE, hw, key, expected):
 def test_large_int_indexing(db_empty, RE, hw, key, expected):
     """Integer-valued catalog key can exceed 32-bit values"""
     db = db_empty
-    RE.md["scan_id"] = 2*33
+    RE.md["scan_id"] = 2**33 - 1
     RE.subscribe(db.insert)
 
     uids = []

--- a/databroker/tests/test_broker.py
+++ b/databroker/tests/test_broker.py
@@ -240,6 +240,7 @@ def test_indexing(db_empty, RE, hw):
 
 
 def test_int64_indexing(db_empty, RE, hw):
+    """numpy.int64 can be used as a catalog key, if it is int-convertable"""
     db = db_empty
     RE.subscribe(db.insert)
 
@@ -247,22 +248,25 @@ def test_int64_indexing(db_empty, RE, hw):
     for i in range(2):
         uids.extend(get_uids(RE(count([hw.det]))))
 
-    integer_index = 1
-    assert isinstance(integer_index, int)
+    # Key is a Scan ID
+    integer_key = 1
+    assert isinstance(integer_key, int)
     with does_not_raise():
-        db[integer_index]
+        db[integer_key]
 
-    integer64_index = np.int64(1)
-    assert not isinstance(integer64_index, int)
-    assert isinstance(integer64_index, numbers.Integral)
+    # Key is a Scan ID
+    integer64_key = np.int64(1)
+    assert not isinstance(integer64_key, int)
+    assert isinstance(integer64_key, numbers.Integral)
     with does_not_raise():
-        db[integer64_index]
+        db[integer64_key]
 
-    integer64_index = np.int64(2**33)
-    assert not isinstance(integer64_index, int)
-    assert isinstance(integer64_index, numbers.Integral)
+    # Key is too large
+    integer64_key = np.int64(2**33)
+    assert not isinstance(integer64_key, int)
+    assert isinstance(integer64_key, numbers.Integral)
     with pytest.raises(KeyError):
-        db[integer64_index]
+        db[integer64_key]
 
 
 def test_full_text_search(db_empty, RE, hw):

--- a/databroker/tests/test_broker.py
+++ b/databroker/tests/test_broker.py
@@ -239,7 +239,6 @@ def test_indexing(db_empty, RE, hw):
         db[-11]
 
 
-@pytest.mark.xfail(reason="Databroker catalog expects int not int64")
 def test_int64_indexing(db_empty, RE, hw):
     db = db_empty
     RE.subscribe(db.insert)
@@ -257,6 +256,12 @@ def test_int64_indexing(db_empty, RE, hw):
     assert not isinstance(integer64_index, int)
     assert isinstance(integer64_index, numbers.Integral)
     with does_not_raise():
+        db[integer64_index]
+
+    integer64_index = np.int64(2**33)
+    assert not isinstance(integer64_index, int)
+    assert isinstance(integer64_index, numbers.Integral)
+    with pytest.raises(KeyError):
         db[integer64_index]
 
 

--- a/databroker/tests/test_broker.py
+++ b/databroker/tests/test_broker.py
@@ -4,11 +4,13 @@ import collections
 import tempfile
 import os
 import logging
+import numbers
 import packaging
 import sys
 import string
 import time as ttime
 import uuid
+from contextlib import nullcontext as does_not_raise
 from datetime import date, timedelta
 import itertools
 from databroker import (wrap_in_doct, wrap_in_deprecated_doct,
@@ -235,6 +237,27 @@ def test_indexing(db_empty, RE, hw):
     with pytest.raises(IndexError):
         # too far back
         db[-11]
+
+
+@pytest.mark.xfail(reason="Databroker catalog expects int not int64")
+def test_int64_indexing(db_empty, RE, hw):
+    db = db_empty
+    RE.subscribe(db.insert)
+
+    uids = []
+    for i in range(2):
+        uids.extend(get_uids(RE(count([hw.det]))))
+
+    integer_index = 1
+    assert isinstance(integer_index, int)
+    with does_not_raise():
+        db[integer_index]
+
+    integer64_index = np.int64(1)
+    assert not isinstance(integer64_index, int)
+    assert isinstance(integer64_index, numbers.Integral)
+    with does_not_raise():
+        db[integer64_index]
 
 
 def test_full_text_search(db_empty, RE, hw):

--- a/databroker/tests/test_broker.py
+++ b/databroker/tests/test_broker.py
@@ -242,10 +242,15 @@ def test_indexing(db_empty, RE, hw):
 @pytest.mark.parametrize(
     "key, expected",
     (
+        # These values are in range...
         (np.int64(1), does_not_raise()),  # Key is a Scan ID
         (np.int64(-1), does_not_raise()),  # Key is Nth-last scan
-        (np.int64(2**33), pytest.raises(KeyError)),  # Key is too large
-        (-np.int64(2**33), pytest.raises(KeyError)),  # Abs(key) is too large
+        # These values are out of range...
+        (np.int64(10), pytest.raises(KeyError)),  # Scan ID does not exist
+        (-np.int64(10), pytest.raises(IndexError)),  # Abs(key) > number of scans
+        # >32-bit values are ok, but these are out of range for this test...
+        (np.int64(2**33), pytest.raises(KeyError)),  # Scan ID does not exist
+        (-np.int64(2**33), pytest.raises(IndexError)),  # Abs(key) > number of scans
     ),
 )
 def test_int64_indexing(db_empty, RE, hw, key, expected):

--- a/databroker/tests/test_broker.py
+++ b/databroker/tests/test_broker.py
@@ -245,6 +245,7 @@ def test_indexing(db_empty, RE, hw):
         (np.int64(1), does_not_raise()),  # Key is a Scan ID
         (np.int64(-1), does_not_raise()),  # Key is Nth-last scan
         (np.int64(2**33), pytest.raises(KeyError)),  # Key is too large
+        (-np.int64(2**33), pytest.raises(KeyError)),  # Abs(key) is too large
     ),
 )
 def test_int64_indexing(db_empty, RE, hw, key, expected):

--- a/databroker/utils.py
+++ b/databroker/utils.py
@@ -2,6 +2,7 @@ from datetime import datetime
 import collections
 import doct
 import glob
+import numbers
 import numpy as np
 import os
 import pytz
@@ -431,3 +432,19 @@ class LazyMap(collections.abc.Mapping):
     def __setstate__(self, mapping):
         self.__mapping = mapping
         self.__lock = threading.Lock()
+
+
+MAX_INT_KEY_VALUE = 2**31 - 1  # 32-bit signed integer
+
+
+def ensure_int_key(key: numbers.Integral) -> int:
+    """Coerce key to int, or raise KeyError if value is too large"""
+    if abs(key) <= MAX_INT_KEY_VALUE:
+        key = int(key)
+    else:
+        reason = " ".join((
+            f"Integer key must be less than +/-{MAX_INT_KEY_VALUE};",
+            f"cannot convert value {key} of type {type(key)}.",
+        ))
+        raise KeyError(reason)
+    return key

--- a/databroker/utils.py
+++ b/databroker/utils.py
@@ -2,7 +2,6 @@ from datetime import datetime
 import collections
 import doct
 import glob
-import numbers
 import numpy as np
 import os
 import pytz
@@ -432,19 +431,3 @@ class LazyMap(collections.abc.Mapping):
     def __setstate__(self, mapping):
         self.__mapping = mapping
         self.__lock = threading.Lock()
-
-
-MAX_INT_KEY_VALUE = 2**31 - 1  # 32-bit signed integer
-
-
-def ensure_int_key(key: numbers.Integral) -> int:
-    """Coerce key to int, or raise KeyError if value is too large"""
-    if abs(key) <= MAX_INT_KEY_VALUE:
-        key = int(key)
-    else:
-        reason = " ".join((
-            f"Integer key must be less than +/-{MAX_INT_KEY_VALUE};",
-            f"cannot convert value {key} of type {type(key)}.",
-        ))
-        raise KeyError(reason)
-    return key


### PR DESCRIPTION
## Description
Databroker will now accept a `numpy.int64` value as a key for accessing scans in a databroker catalog, ~~as long as that value can be safely converted to a python int (int32). Otherwise a `KeyError` is raised.~~ Behavior of using the int-valued key is unchanged by this PR: The key is treated as a `scan_id` value if positive, or the `N`th-most recent scan index if negative. Suitable unit tests have been added to verify this.

## Motivation and Context
Databroker is frequently used in conjunction with pandas. By default pandas imports integer columns as `numpy.int64`; databroker then raises an exception when someone tries to use the int64-valued `scan_id` as a catalog key.

Although type conversion could be done manually by the calling code, this is such a common scenario that it would improve out-of-the-box user experience to handle this case within databroker.

~~### Note: Stacked PR~~
~~This PR builds upon outstanding PR https://github.com/bluesky/databroker/pull/803. Please wait until https://github.com/bluesky/databroker/pull/803 has been accepted before merging this PR.~~

## How Has This Been Tested?
Passes [linter](https://github.com/padraic-shafer/databroker/actions/runs/8674817684) and [unit tests](https://github.com/padraic-shafer/databroker/actions/runs/8674817685) in GH actions of forked repo.

_EDITED to clarify the intention that the int64-valued key be treated as an int-valued key; other than that, databroker behaves no differently._