### PR TITLE
Bump tiled in Dockerfile to v0.1.0b2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ghcr.io/bluesky/tiled:v0.1.0a120 as base
+FROM ghcr.io/bluesky/tiled:v0.1.0b2 as base
 
 FROM base as builder
 


### PR DESCRIPTION
The minimum version required is unchanged; this just bumps the version we derived from in `Dockerfile`