### PR TITLE
Update for tiled v0.1.0b3

### DIFF
--- a/databroker/mongo_normalized.py
+++ b/databroker/mongo_normalized.py
@@ -272,7 +272,7 @@ class BlueskyRun(MapAdapter, BlueskyRunMixin):
         metadata = dict(collections.ChainMap(transformed, self._metadata))
         return metadata
 
-    async def update_metadata(self, metadata=None, specs=None):
+    async def replace_metadata(self, metadata=None, specs=None):
         if "start" not in metadata:
             raise NotImplementedError(
                 "A start document is required when updating metadata."
@@ -487,7 +487,7 @@ class BlueskyEventStream(MapAdapter, BlueskyEventStreamMixin):
     def key(self):
         return self._metadata["descriptors"][0]["name"]
 
-    async def update_metadata(self, metadata=None, specs=None):
+    async def replace_metadata(self, metadata=None, specs=None):
         if "descriptors" not in metadata:
             raise NotImplementedError("Update_metadata method requires descriptors.")
         # Update descriptors

--- a/requirements-client.txt
+++ b/requirements-client.txt
@@ -1,4 +1,4 @@
 mongoquery
 msgpack >=1.0.0
 orjson
-tiled[client] >=0.1.0a120
+tiled[client] >=0.1.0b3

--- a/requirements-server.txt
+++ b/requirements-server.txt
@@ -13,7 +13,7 @@ pytz
 rich
 starlette
 suitcase-mongo >=0.5.0
-tiled[server] >=0.1.0a120
+tiled[server] >=0.1.0b3
 toolz
 typer
 tzlocal

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -17,6 +17,6 @@ sphinx
 suitcase-jsonl >=0.1.0b2
 suitcase-mongo >=0.5.0
 suitcase-msgpack >=0.2.2
-tiled[all] >=0.1.0a120
+tiled[all] >=0.1.0b3
 ujson
 vcrpy


### PR DESCRIPTION
This updates databroker for this backward-incompatible change in how metadata update works. The method was renamed from `update_metadata` to `replace_metadata` to (1) be unambiguous that the input will fully replace any existing metadata and (2) leave space for more efficient update/patch methods in the future.