### PR TITLE
Numpy 2 fix

### DIFF
--- a/databroker/mongo_normalized.py
+++ b/databroker/mongo_normalized.py
@@ -956,7 +956,7 @@ class DatasetFromDocuments:
             else:
                 nonscalars.append(key)
                 estimated_nonscalar_row_bytesizes.append(
-                    numpy.product(data_key["shape"]) * 8
+                    numpy.prod(data_key["shape"]) * 8
                 )
 
         # Aim for 10 MB pages to stay safely clear the MongoDB's hard limit

--- a/databroker/tests/test_broker.py
+++ b/databroker/tests/test_broker.py
@@ -1289,3 +1289,22 @@ def test_update(db, RE, hw):
     with pytest.raises(ValueError):
         c[uid].update_metadata({"start": {"uid": "not allowed to change this"}})
 
+
+def test_img_read(db, RE, hw):
+    "Test reading 2D data referenced by Datum, Resource."
+    RE.subscribe(db.insert)
+    if not hasattr(db, "v2"):
+        raise pytest.skip("v0 has no v2 accessor")
+    c = db.v2
+    uid, = get_uids(RE(count([hw.img], 5)))
+    c[uid]["primary"]["data"]["img"][:]
+
+
+def test_direct_img_read(db, RE, hw):
+    "Test reading 2D data placed directly in the Event document."
+    RE.subscribe(db.insert)
+    if not hasattr(db, "v2"):
+        raise pytest.skip("v0 has no v2 accessor")
+    c = db.v2
+    uid, = get_uids(RE(count([hw.direct_img], 5)))
+    c[uid]["primary"]["data"]["img"][:]


### PR DESCRIPTION
We saw a failure on numpy 2.0 due to an untested codepath in the case of nonscalar data placed directly in an Event document.

New unit test exercises the bug:

```
FAILED databroker/tests/test_broker.py::test_direct_img_read[mongo-tiled-False] - AttributeError: module 'numpy' has no attribute 'product'
FAILED databroker/tests/test_broker.py::test_direct_img_read[mongo-tiled-True] - AttributeError: module 'numpy' has no attribute 
'product'
```