### PR TITLE
Add mongoquery as a server dep.

### DIFF
--- a/requirements-server.txt
+++ b/requirements-server.txt
@@ -7,6 +7,7 @@ json-merge-patch
 jsonpatch
 jsonschema
 mongomock
+mongoquery
 msgpack >=1.0.0
 pims
 pydantic


### PR DESCRIPTION
This addresses a bug caught in prod, where the databroker container image is missing this dependency. It comes up in situations when a `ScanID` where is mixed with other query types.