### PR TITLE
Update for tiled v0.1.0b8

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ghcr.io/bluesky/tiled:v0.1.0b7 as base
+FROM ghcr.io/bluesky/tiled:v0.1.0b8 as base
 
 FROM base as builder
 

--- a/databroker/server.py
+++ b/databroker/server.py
@@ -6,7 +6,7 @@ from jsonschema import ValidationError
 from event_model import DocumentNames, schema_validators
 from fastapi import APIRouter, HTTPException, Request
 import pydantic
-from tiled.server.core import PatchedStreamingResponse
+from starlette.responses import StreamingResponse
 from tiled.server.dependencies import SecureEntry
 
 
@@ -44,13 +44,13 @@ def get_documents(
                     yield packer.pack({"name": name, "doc": doc})
 
             generator = generator_func()
-            return PatchedStreamingResponse(
+            return StreamingResponse(
                 generator, media_type="application/x-msgpack"
             )
         if media_type == "application/json-seq":
             # (name, doc) pairs as newline-delimited JSON
             generator = (json.dumps({"name": name, "doc": doc}) + "\n" for name, doc in run.documents(fill=fill))
-            return PatchedStreamingResponse(
+            return StreamingResponse(
                 generator, media_type="application/json-seq"
             )
     else:

--- a/requirements-client.txt
+++ b/requirements-client.txt
@@ -1,4 +1,4 @@
 mongoquery
 msgpack >=1.0.0
 orjson
-tiled[client] >=0.1.0b4
+tiled[client] >=0.1.0b8

--- a/requirements-server.txt
+++ b/requirements-server.txt
@@ -16,7 +16,7 @@ pytz
 rich
 starlette
 suitcase-mongo >=0.5.0
-tiled[server] >=0.1.0b4
+tiled[server] >=0.1.0b8
 toolz
 typer
 tzlocal

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -17,6 +17,6 @@ sphinx
 suitcase-jsonl >=0.1.0b2
 suitcase-mongo >=0.5.0
 suitcase-msgpack >=0.2.2
-tiled[all] >=0.1.0b4
+tiled[all] >=0.1.0b8
 ujson
 vcrpy


### PR DESCRIPTION
Tiled v0.1.0b8 dropped `PatchedStreamResponse` because said patch is not longer needed, due to a change in Starlette. This changes Databroker to use the Starlette object instead.