### PR TITLE
FIX: return and empty dict for type stability

### DIFF
--- a/databroker/v1.py
+++ b/databroker/v1.py
@@ -67,6 +67,7 @@ class Registry:
             "details are handled for you on the server side, so you should not worry "
             "about this message unless you encounter trouble loading large array data."
         )
+        return {}
 
     def register_handler(self, *args, **kwargs):
         warnings.warn(


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

Even though the property is deprecated, we should maintain type stability

