### PR TITLE
FIX: data padding bug in mongo_normalized

### DIFF
--- a/databroker/mongo_normalized.py
+++ b/databroker/mongo_normalized.py
@@ -2244,11 +2244,11 @@ def default_validate_shape(key, data, expected_shape):
         else:  # margin == 0
             padding.append((0, 0))
             trimming.append(slice(None, None))
-        # TODO Rethink this!
-        # We cannot do NaN because that does not work for integers
-        # and it is too late to change our mind about the data type.
-        padded = numpy.pad(data, padding, "edge")
-        padded_and_trimmed = padded[tuple(trimming)]
+    # TODO Rethink this!
+    # We cannot do NaN because that does not work for integers
+    # and it is too late to change our mind about the data type.
+    padded = numpy.pad(data, padding, "edge")
+    padded_and_trimmed = padded[tuple(trimming)]
     return padded_and_trimmed
 
 

--- a/databroker/mongo_normalized.py
+++ b/databroker/mongo_normalized.py
@@ -2225,7 +2225,6 @@ def default_validate_shape(key, data, expected_shape):
         )
     # Pad at the "end" along any dimension that is too short.
     padding = []
-    trimming = []
     for actual, expected in zip(data.shape, expected_shape):
         margin = expected - actual
         # Limit how much padding or trimming we are willing to do.

--- a/databroker/tests/test_validate_shape.py
+++ b/databroker/tests/test_validate_shape.py
@@ -9,6 +9,7 @@ from ..mongo_normalized import MongoAdapter, BadShapeMetadata
 import numpy as np
 import pytest
 
+
 def test_validate_shape(tmpdir):
     # custom_validate_shape will mutate this to show it has been called
     shapes = []
@@ -33,13 +34,16 @@ def test_validate_shape(tmpdir):
         assert shapes
 
 
-@pytest.mark.parametrize("shape,expected_shape",[
-    ( (10,), (11,) ),
-    ( (10,20), (10,21) ),
-    ( (10,20,30), (10,21,30) ),
-    ( (10,20,30), (10,20,31) ),
-    ( (20,20,20,20), (20,21,20,22) ),
-])
+@pytest.mark.parametrize(
+    "shape,expected_shape",
+    [
+        ((10,), (11,)),
+        ((10, 20), (10, 21)),
+        ((10, 20, 30), (10, 21, 30)),
+        ((10, 20, 30), (10, 20, 31)),
+        ((20, 20, 20, 20), (20, 21, 20, 22)),
+    ],
+)
 def test_padding(tmpdir, shape, expected_shape):
     adapter = MongoAdapter.from_mongomock()
 
@@ -62,12 +66,16 @@ def test_padding(tmpdir, shape, expected_shape):
         (uid,) = RE(count([direct_img]))
         assert client[uid]["primary"]["data"]["img"][0].shape == expected_shape
 
-@pytest.mark.parametrize("shape,expected_shape",[
-    ( (10,), (11,12) ),
-    ( (10,20), (10,200) ),
-    #( (20,20,20,20), (20,21,20,200) ),  # range with page_size=0 because expected byte size is too large
-    #( (10,20), (9,20) ),  # docstring says this should raise BadShapeMetadata, but code doesn't
-])
+
+@pytest.mark.parametrize(
+    "shape,expected_shape",
+    [
+        ((10,), (11, 12)),
+        ((10, 20), (10, 200)),
+        # ( (20,20,20,20), (20,21,20,200) ),  # range with page_size=0 because expected byte size is too large
+        # ( (10,20), (9,20) ),  # docstring says this should raise BadShapeMetadata, but code doesn't
+    ],
+)
 def test_default_validate_shape(tmpdir, shape, expected_shape):
     adapter = MongoAdapter.from_mongomock()
 
@@ -90,4 +98,3 @@ def test_default_validate_shape(tmpdir, shape, expected_shape):
         (uid,) = RE(count([direct_img]))
         with pytest.raises(BadShapeMetadata):
             client[uid]["primary"]["data"]["img"][:]
-

--- a/databroker/tests/test_validate_shape.py
+++ b/databroker/tests/test_validate_shape.py
@@ -1,11 +1,13 @@
 from bluesky import RunEngine
 from bluesky.plans import count
-from ophyd.sim import img
+from ophyd.sim import img, DirectImage
 from tiled.client import Context, from_context
 from tiled.server.app import build_app
 
-from ..mongo_normalized import MongoAdapter
+from ..mongo_normalized import MongoAdapter, BadShapeMetadata
 
+import numpy as np
+import pytest
 
 def test_validate_shape(tmpdir):
     # custom_validate_shape will mutate this to show it has been called
@@ -29,3 +31,63 @@ def test_validate_shape(tmpdir):
         assert not shapes
         client[uid]["primary"]["data"]["img"][:]
         assert shapes
+
+
+@pytest.mark.parametrize("shape,expected_shape",[
+    ( (10,), (11,) ),
+    ( (10,20), (10,21) ),
+    ( (10,20,30), (10,21,30) ),
+    ( (10,20,30), (10,20,31) ),
+    ( (20,20,20,20), (20,21,20,22) ),
+])
+def test_padding(tmpdir, shape, expected_shape):
+    adapter = MongoAdapter.from_mongomock()
+
+    direct_img = DirectImage(
+        func=lambda: np.array(np.ones(shape)), name="direct", labels={"detectors"}
+    )
+    direct_img.img.name = "img"
+
+    with Context.from_app(build_app(adapter), token_cache=tmpdir) as context:
+        client = from_context(context)
+
+        def post_document(name, doc):
+            if name == "descriptor":
+                doc["data_keys"]["img"]["shape"] = expected_shape
+
+            client.post_document(name, doc)
+
+        RE = RunEngine()
+        RE.subscribe(post_document)
+        (uid,) = RE(count([direct_img]))
+        assert client[uid]["primary"]["data"]["img"][0].shape == expected_shape
+
+@pytest.mark.parametrize("shape,expected_shape",[
+    ( (10,), (11,12) ),
+    ( (10,20), (10,200) ),
+    #( (20,20,20,20), (20,21,20,200) ),  # range with page_size=0 because expected byte size is too large
+    #( (10,20), (9,20) ),  # docstring says this should raise BadShapeMetadata, but code doesn't
+])
+def test_default_validate_shape(tmpdir, shape, expected_shape):
+    adapter = MongoAdapter.from_mongomock()
+
+    direct_img = DirectImage(
+        func=lambda: np.array(np.ones(shape)), name="direct", labels={"detectors"}
+    )
+    direct_img.img.name = "img"
+
+    with Context.from_app(build_app(adapter), token_cache=tmpdir) as context:
+        client = from_context(context)
+
+        def post_document(name, doc):
+            if name == "descriptor":
+                doc["data_keys"]["img"]["shape"] = expected_shape
+
+            client.post_document(name, doc)
+
+        RE = RunEngine()
+        RE.subscribe(post_document)
+        (uid,) = RE(count([direct_img]))
+        with pytest.raises(BadShapeMetadata):
+            client[uid]["primary"]["data"]["img"][:]
+

--- a/databroker/tests/test_validate_shape.py
+++ b/databroker/tests/test_validate_shape.py
@@ -39,6 +39,7 @@ def test_validate_shape(tmpdir):
     [
         ((10,), (11,)),
         ((10, 20), (10, 21)),
+        ((10, 20), (10, 19)),
         ((10, 20, 30), (10, 21, 30)),
         ((10, 20, 30), (10, 20, 31)),
         ((20, 20, 20, 20), (20, 21, 20, 22)),
@@ -72,8 +73,8 @@ def test_padding(tmpdir, shape, expected_shape):
     [
         ((10,), (11, 12)),
         ((10, 20), (10, 200)),
-        # ( (20,20,20,20), (20,21,20,200) ),  # range with page_size=0 because expected byte size is too large
-        # ( (10,20), (9,20) ),  # docstring says this should raise BadShapeMetadata, but code doesn't
+        ( (20,20,20,20), (20,21,20,200) ),
+        ( (10,20), (5,20) ),
     ],
 )
 def test_default_validate_shape(tmpdir, shape, expected_shape):

--- a/databroker/tests/test_validate_shape.py
+++ b/databroker/tests/test_validate_shape.py
@@ -73,8 +73,8 @@ def test_padding(tmpdir, shape, expected_shape):
     [
         ((10,), (11, 12)),
         ((10, 20), (10, 200)),
-        ( (20,20,20,20), (20,21,20,200) ),
-        ( (10,20), (5,20) ),
+        ((20, 20, 20, 20), (20, 21, 20, 200)),
+        ((10, 20), (5, 20)),
     ],
 )
 def test_default_validate_shape(tmpdir, shape, expected_shape):


### PR DESCRIPTION
We had several design discussions about implicit padding and trimming.  I think it probably isn't the right choice to pad and trim by default, because it can affect scientific results.  This PR fixes a bug with the implicit padding and adds tests.
I think more investigation is required to figure out how to pad and trim in a better way, that is out of the scope of this PR. - @gwbischof 

`default_validate_shape` had some trimming logic that wasn't doing anything, the trimming was happening elsewhere in the code.

`default_validate_shape` was falling for multi-dimensional data.

Buggy logic:
```
loop:
    compute padding args
    apply padding
```

Fix:
```
loop:
    compute padding args

apply padding
```


