### PR TITLE
Fix and test 'chunks' escape hatch.

### DIFF
--- a/databroker/mongo_normalized.py
+++ b/databroker/mongo_normalized.py
@@ -160,7 +160,7 @@ def structure_from_descriptor(descriptor, sub_dict, max_seq_num, unicode_columns
         numpy_dtype = dtype.to_numpy_dtype()
         if "chunks" in field_metadata:
             # If the Event Descriptor tells us a preferred chunking, use that.
-            suggested_chunks = field_metadata["chunks"]
+            suggested_chunks = tuple(tuple(chunks) for chunks in field_metadata["chunks"])
         elif (0 in shape) or (numpy_dtype.itemsize == 0):
             # special case to avoid warning from dask
             suggested_chunks = shape


### PR DESCRIPTION
Data is typically chunked using a heuristic. We support a `"chunks"` key, next to `"shape"` in the descriptor, as a way to override the heuristic. This has been in the codebase for quite awhile but evidently not ever actually _run_ because it is broken. This fixes it and adds a unit test. The fix was also tested in the wild:

```py
In [1]: from tiled.client import from_profile, show_logs

In [2]: c = from_profile('tes')

In [3]: c['95820398-d829-4088-a023-746a78c01f4f']['primary']['data']['fluor']
```

Looking forward, we agree that StreamResource will enable chunking. Putting chunks in the descriptor is just an escape hatch for legacy documents.