### PR TITLE
Address bit rot

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -16,7 +16,7 @@ jobs:
         - 27017:27017
     strategy:
       matrix:
-        python-version: ["3.8", "3.9", "3.10", "3.11"]
+        python-version: ["3.9", "3.10", "3.11", "3.12"]
       fail-fast: false
     steps:
 

--- a/databroker/headersource/sqlite.py
+++ b/databroker/headersource/sqlite.py
@@ -88,7 +88,7 @@ class EventCollection(object):
     def reconnect(self):
         for fn in os.listdir(self._dirpath):
             # Cache connections to every sqlite file.
-            match = re.match('([0-9a-z-]+)\.sqlite', fn)
+            match = re.match(r'([0-9a-z-]+)\.sqlite', fn)
             if match is None:
                 # skip unrecognized file
                 continue

--- a/databroker/mongo_normalized.py
+++ b/databroker/mongo_normalized.py
@@ -1898,13 +1898,13 @@ class SimpleAccessPolicy:
             )
         return id
 
-    def allowed_scopes(self, node, principal):
+    def allowed_scopes(self, node, principal, path_parts):
         # The simple policy does not provide for different Principals to
         # have different scopes on different Nodes. If the Principal has access,
         # they have the same hard-coded access everywhere.
         return self.scopes
 
-    def filters(self, node, principal, scopes):
+    def filters(self, node, principal, scopes, path_parts):
         if not scopes.issubset(self.scopes):
             return NO_ACCESS
         id = self._get_id(principal)

--- a/databroker/mongo_normalized.py
+++ b/databroker/mongo_normalized.py
@@ -1898,13 +1898,13 @@ class SimpleAccessPolicy:
             )
         return id
 
-    def allowed_scopes(self, node, principal, path_parts):
+    async def allowed_scopes(self, node, principal, path_parts):
         # The simple policy does not provide for different Principals to
         # have different scopes on different Nodes. If the Principal has access,
         # they have the same hard-coded access everywhere.
         return self.scopes
 
-    def filters(self, node, principal, scopes, path_parts):
+    async def filters(self, node, principal, scopes, path_parts):
         if not scopes.issubset(self.scopes):
             return NO_ACCESS
         id = self._get_id(principal)

--- a/databroker/tests/test_access_policy.py
+++ b/databroker/tests/test_access_policy.py
@@ -51,9 +51,9 @@ def test_access_policy_example(tmpdir):
             }
         ],
     }
-    with Context.from_app(build_app_from_config(config), token_cache=tmpdir) as context:
+    with Context.from_app(build_app_from_config(config)) as context:
         with enter_username_password("alice", "secret"):
-            client = from_context(context, prompt_for_reauthentication=True)
+            client = from_context(context)
 
         def post_document(name, doc):
             client.post_document(name, doc)

--- a/databroker/tests/test_config.py
+++ b/databroker/tests/test_config.py
@@ -1,6 +1,5 @@
 import copy
 import databroker.databroker
-import imp
 import os
 import pytest
 import six

--- a/databroker/tests/test_validate_shape.py
+++ b/databroker/tests/test_validate_shape.py
@@ -29,7 +29,7 @@ def test_padding(tmpdir, shape, expected_shape):
     )
     direct_img.img.name = "img"
 
-    with Context.from_app(build_app(adapter), token_cache=tmpdir) as context:
+    with Context.from_app(build_app(adapter)) as context:
         client = from_context(context)
 
         def post_document(name, doc):
@@ -72,7 +72,7 @@ def test_custom_chunking(tmpdir, chunks, shape, expected_chunks):
     )
     direct_img.img.name = "img"
 
-    with Context.from_app(build_app(adapter), token_cache=tmpdir) as context:
+    with Context.from_app(build_app(adapter)) as context:
         client = from_context(context, "dask")
 
         def post_document(name, doc):
@@ -104,7 +104,7 @@ def test_validate_shape_exceptions(tmpdir, shape, expected_shape):
     )
     direct_img.img.name = "img"
 
-    with Context.from_app(build_app(adapter), token_cache=tmpdir) as context:
+    with Context.from_app(build_app(adapter)) as context:
         client = from_context(context)
 
         def post_document(name, doc):
@@ -130,7 +130,7 @@ def test_custom_validate_shape(tmpdir):
 
     adapter = MongoAdapter.from_mongomock(validate_shape=custom_validate_shape)
 
-    with Context.from_app(build_app(adapter), token_cache=tmpdir) as context:
+    with Context.from_app(build_app(adapter)) as context:
         client = from_context(context)
 
         def post_document(name, doc):

--- a/requirements-client.txt
+++ b/requirements-client.txt
@@ -1,4 +1,4 @@
 mongoquery
 msgpack >=1.0.0
 orjson
-tiled[client] >=0.1.0b13
+tiled[client] >=0.1.0-b13

--- a/requirements-client.txt
+++ b/requirements-client.txt
@@ -1,4 +1,4 @@
 mongoquery
 msgpack >=1.0.0
 orjson
-tiled[client] >=0.1.0b9
+tiled[client] >=0.1.0b13

--- a/requirements-server.txt
+++ b/requirements-server.txt
@@ -16,7 +16,7 @@ pytz
 rich
 starlette
 suitcase-mongo >=0.5.0
-tiled[server] >=0.1.0b13
+tiled[server] >=0.1.0-b13
 toolz
 typer
 tzlocal

--- a/requirements-server.txt
+++ b/requirements-server.txt
@@ -16,7 +16,7 @@ pytz
 rich
 starlette
 suitcase-mongo >=0.5.0
-tiled[server] >=0.1.0b9
+tiled[server] >=0.1.0b13
 toolz
 typer
 tzlocal

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -17,6 +17,6 @@ sphinx
 suitcase-jsonl >=0.1.0b2
 suitcase-mongo >=0.5.0
 suitcase-msgpack >=0.2.2
-tiled[all] >=0.1.0b13
+tiled[all] >=0.1.0-b13
 ujson
 vcrpy

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -17,6 +17,6 @@ sphinx
 suitcase-jsonl >=0.1.0b2
 suitcase-mongo >=0.5.0
 suitcase-msgpack >=0.2.2
-tiled[all] >=0.1.0b9
+tiled[all] >=0.1.0b13
 ujson
 vcrpy


### PR DESCRIPTION
- Bumped minimum Tiled version to latest
- Tiled AccesControlPolicy methods grew an additional required parameter, `path_parts`, and changed from sync to async.
- Tiled auth-related parameters changed.
- Python 3.8 is EOL. Python 3.12 was added. Python 3.13 was not yet added, as Tiled is not testing against it 3.13. (Last we checked some of our dependencies were still catching up.)