### PR TITLE
Add bluesky-tiled-plugins dep

### DIFF
--- a/requirements-client.txt
+++ b/requirements-client.txt
@@ -1,3 +1,4 @@
+bluesky-tiled-plugins
 msgpack >=1.0.0
 orjson
 tiled[client] >=0.1.0-b13


### PR DESCRIPTION
This can now be added because `bluesky-tiled-plugins` is released on PyPI.

On CI, it works as before: we install from source.