### PR TITLE
Add bluesky-tiled-plugins as a server dependency

### DIFF
--- a/requirements-server.txt
+++ b/requirements-server.txt
@@ -1,4 +1,5 @@
 area-detector-handlers
+bluesky-tiled-plugins
 cachetools
 entrypoints
 event-model


### PR DESCRIPTION
## Description
This PR adds `bluesky-tiled-plugins` as a "server" dependency.

## Motivation and Context
The sub package `bluesky-tiled-plugins` is used by the databroker server that gets built as a docker image. Starting up the container fails with the message:

```
│ /opt/venv/lib/python3.12/site-packages/databroker/query_impl.py:16 in        │
│ <module>                                                                     │
│                                                                              │
│    13 │   QueryValueError,                                                   │
│    14 │   Regex,                                                             │
│    15 )                                                                      │
│ ❱  16 from bluesky_tiled_plugins.queries import (                            │
│    17 │   _PartialUID,                                                       │
│    18 │   _ScanID,                                                           │
│    19 │   ScanIDRange,                                                       │
│                                                                              │
│ ╭───────────────────────────────── locals ─────────────────────────────────╮ │
│ │ collections = <module 'collections' from                                 │ │
│ │               '/usr/local/lib/python3.12/collections/__init__.py'>       │ │
│ ╰──────────────────────────────────────────────────────────────────────────╯ │
╰──────────────────────────────────────────────────────────────────────────────╯
ModuleNotFoundError: No module named 'bluesky_tiled_plugins'
```

## How Has This Been Tested?
Tested locally by updating the docker-compose.yml to build and run an image from the local repo.

```
...
services:
  tiled:
    image: ghcr.io/bluesky/databroker:local
    build:
      context: "."  # Local repo directory
      tags:
        - databroker:local
...
```

```
TILED_SINGLE_USER_API_KEY=test docker compose up -d

Using configuration from /deploy/config
[-] INFO:     Started server process [1]
[-] INFO:     Waiting for application startup.
Tiled version 0.1.0b16
[-] INFO:     Application startup complete.
[-] INFO:     Uvicorn running on http://0.0.0.0:8000 (Press CTRL+C to quit)

```

<!--
## Screenshots (if appropriate):
-->
