### PR TITLE
Adjust to API change in FullText query.

### DIFF
--- a/databroker/mongo_normalized.py
+++ b/databroker/mongo_normalized.py
@@ -1857,7 +1857,7 @@ def full_text_search(query, catalog):
             return BlueskyMapAdapter(dict(catalog)).search(query)
 
     return catalog.apply_mongo_query(
-        {"$text": {"$search": query.text, "$caseSensitive": query.case_sensitive}},
+        {"$text": {"$search": query.text, "$caseSensitive": False}},
     )
 
 


### PR DESCRIPTION
The `case_insensitive` attribute was removed from `FullText` a little more than a year ago in https://github.com/bluesky/tiled/commit/eb79bdb8aea1dec2601c29344e22deedc9f87799#diff-39c6c64d38798eb3df5586ef8342fc2f7b947a43b8f762368f0ef4d2e8545a8d. This needs to be updated to match.