### PR TITLE
Handle service principles in access policy.

### DIFF
--- a/databroker/mongo_normalized.py
+++ b/databroker/mongo_normalized.py
@@ -1899,6 +1899,9 @@ class SimpleAccessPolicy:
             self.access_lists[key] = value
 
     def _get_id(self, principal):
+        # Services have no identities; just use the uuid.
+        if principal.type == "service":
+            return str(principal.uuid)
         # Get the id (i.e. username) of this Principal for the
         # associated authentication provider.
         for identity in principal.identities:


### PR DESCRIPTION
Tested against production database at NSLS-II. On `main`, using the API key of an unrecognized Service Principal produces a 500 error:

```
ValueError: Principcal Principal(id=131, time_created=datetime.datetime(2024, 5, 23, 14, 12, 38, 248410, tzinfo=datetime.timezone.utc), uuid=UUID(uuid=56001d0c-cb9d-4415-8b16-84ded6881b09'), type=<PrincipalType.service: 'service'>, time_updated=None, identities=[], roles=[Role(name='user', description='Default Role for users.', time_created=datetime.datetime(2022, 2, 9, 16, 7, 54, 870299, tzinfo=datetime.timezone.utc), id=1, scopes=['read:metadata', 'read:data', 'apikeys', 'write:metadata', 'write:data', 'create'], time_updated=datetime.datetime(2022, 12, 9, 12, 38, 50, 883734, tzinfo=datetime.timezone.utc))]) has no identity from provider pam. Its identities are: []
```

With this PR, it shows an empty Catalog, because the SP is not configured in the list of users (principals) with access:

```py
In [5]: c['cms']['bluesky_sandbox']
Out[5]: <Catalog {}>

In [7]: c.context
Out[7]: <Context authenticated as service '56001d0c-cb9d-4415-8b16-84ded6881b09' with API key 'dad3f0b8...'>
```

Now adding the SP's UUID to the list of principals with access:

```py
In [12]: c['cms']['bluesky_sandbox']
Out[12]: <Catalog {'0', '00', 'd909eb5d-44d6-447d-9583-f942ae792dd2', ...} ~67083 entries>
```