### PR TITLE
feat: serialize named tuples as dicts

### DIFF
--- a/bluesky-tiled-plugins/bluesky_tiled_plugins/catalog_of_bluesky_runs.py
+++ b/bluesky-tiled-plugins/bluesky_tiled_plugins/catalog_of_bluesky_runs.py
@@ -147,7 +147,15 @@ class CatalogOfBlueskyRuns(Container):
 
     def post_document(self, name, doc):
         link = self.item["links"]["self"].replace("/metadata", "/documents", 1)
-        response = self.context.http_client.post(
-            link, content=safe_json_dump({"name": name, "doc": doc}, default=self._namedtuple_asdict_default)
-        )
+        try:
+            response = self.context.http_client.post(
+                link, content=safe_json_dump({"name": name, "doc": doc}, default=self._namedtuple_asdict_default)
+            )
+        except TypeError as e:
+            if "got an unexpected keyword argument" in str(e):
+                response = self.context.http_client.post(
+                    link, content=safe_json_dump({"name": name, "doc": doc})
+                )
+            else:
+                raise
         handle_error(response)

--- a/bluesky-tiled-plugins/bluesky_tiled_plugins/catalog_of_bluesky_runs.py
+++ b/bluesky-tiled-plugins/bluesky_tiled_plugins/catalog_of_bluesky_runs.py
@@ -138,9 +138,16 @@ class CatalogOfBlueskyRuns(Container):
             self._v1 = Broker(self)
         return self._v1
 
+    @staticmethod
+    def _namedtuple_asdict_default(obj):
+        """Convert NamedTuple to dict before serialization."""
+        if isinstance(obj, tuple) and hasattr(obj, "_asdict"):  # NamedTuple check
+            return obj._asdict()
+        raise TypeError(f"Type {type(obj)} is not JSON serializable")
+
     def post_document(self, name, doc):
         link = self.item["links"]["self"].replace("/metadata", "/documents", 1)
         response = self.context.http_client.post(
-            link, content=safe_json_dump({"name": name, "doc": doc})
+            link, content=safe_json_dump({"name": name, "doc": doc}, default=self._namedtuple_asdict_default)
         )
         handle_error(response)

--- a/databroker/client.py
+++ b/databroker/client.py
@@ -1,5 +1,4 @@
 # This module is now a back-compat shim. The objects are defined in a
 # separate package, bluesky_tiled_plugins, that resides in the same
 # git repository as databroker.
-from bluesky_tiled_plugins import (BlueskyEventStream,  # noqa: F401
-                                   BlueskyRun, CatalogOfBlueskyRuns)
+from bluesky_tiled_plugins import BlueskyEventStream, BlueskyRun, CatalogOfBlueskyRuns  # noqa: F401

--- a/databroker/client.py
+++ b/databroker/client.py
@@ -1,4 +1,5 @@
 # This module is now a back-compat shim. The objects are defined in a
 # separate package, bluesky_tiled_plugins, that resides in the same
 # git repository as databroker.
-from bluesky_tiled_plugins import BlueskyRun, CatalogOfBlueskyRuns, BlueskyEventStream  # noqa: F401
+from bluesky_tiled_plugins import (BlueskyEventStream,  # noqa: F401
+                                   BlueskyRun, CatalogOfBlueskyRuns)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Take advantage of [dependent PR in Tiled](https://github.com/bluesky/tiled/pull/895) to serialize NamedTuple like objects as dictionaries. 

## Description
<!--- Describe your changes in detail -->
Add function to be consumed as default serialization. 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
This default functionality was removed from `orjson` in version 3.10, and causes problems with Bluesky use (e.g., hklpy). 


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

<!--
## Screenshots (if appropriate):
-->
