### PR TITLE
Fix access to timestamps in external data_keys

### DIFF
--- a/databroker/assets/tests/test_handlers.py
+++ b/databroker/assets/tests/test_handlers.py
@@ -325,7 +325,7 @@ class Test_ADTiff_files(_with_path):
         self.fn_list = []
         for j in range(self.n_frames * self.fpp):
             fn = self.template % (self.filepath, self.fname, j)
-            tifffile.imsave(fn, np.ones(self.fr_shape) * j)
+            tifffile.imwrite(fn, np.ones(self.fr_shape) * j)
             self.fn_list.append(fn)
 
     def test_read(self):

--- a/databroker/mongo_normalized.py
+++ b/databroker/mongo_normalized.py
@@ -1013,7 +1013,7 @@ class DatasetFromDocuments:
             keys, expected_shapes, is_externals
         ):
             column = columns[key]
-            if is_external:
+            if is_external and (self._sub_dict == "data"):
                 filled_column = []
                 for datum_id in column:
                     # HACK to adapt Filler which is designed to consume whole,

--- a/databroker/tests/test_broker.py
+++ b/databroker/tests/test_broker.py
@@ -1298,6 +1298,7 @@ def test_img_read(db, RE, hw):
     c = db.v2
     uid, = get_uids(RE(count([hw.img], 5)))
     c[uid]["primary"]["data"]["img"][:]
+    c[uid]["primary"]["timestamps"]["img"][:]
 
 
 def test_direct_img_read(db, RE, hw):


### PR DESCRIPTION
An event document containing a `datum_id` still has the associated timestamp inline. Don't try to fill it.

Unit test reproduces a bug found on the floor and fails, next commit fixes the failure.