### PR TITLE
Raise a v3 NotImplementedError

### DIFF
--- a/bluesky-tiled-plugins/bluesky_tiled_plugins/bluesky_run.py
+++ b/bluesky-tiled-plugins/bluesky_tiled_plugins/bluesky_run.py
@@ -133,6 +133,11 @@ class BlueskyRun(Container):
 
 
 class BlueskyRunV2(BlueskyRun):
+    """A MongoDB-native layout of BlueskyRuns
+
+    This layout has been in use prior to the introduction of SQL backend in May 2025.
+    """
+
     _version = "2.0"
 
     def __new__(cls, context, *, item, structure_clients, **kwargs):
@@ -158,6 +163,9 @@ class BlueskyRunV2(BlueskyRun):
 
     @property
     def v3(self):
+        if not self._is_sql(self.item):
+            raise NotImplementedError("v3 is not available for MongoDB-based BlueskyRun")
+
         structure_clients = copy.copy(self.structure_clients)
         structure_clients.set("BlueskyRun", lambda: BlueskyRunV3)
         return BlueskyRunV3(self.context, item=self.item, structure_clients=structure_clients)
@@ -252,6 +260,8 @@ class BlueskyRunV2SQL(BlueskyRunV2, _BlueskyRunSQL):
 
 
 class BlueskyRunV3(_BlueskyRunSQL):
+    """A BlueskyRun that is backed by a SQL database."""
+
     _version = "3.0"
 
     def __new__(cls, context, *, item, structure_clients, **kwargs):

--- a/bluesky-tiled-plugins/bluesky_tiled_plugins/bluesky_run.py
+++ b/bluesky-tiled-plugins/bluesky_tiled_plugins/bluesky_run.py
@@ -6,13 +6,12 @@ import keyword
 import warnings
 from datetime import datetime
 
-from event_model import StreamDatum, StreamResource
 from tiled.client.container import Container
 from tiled.client.utils import handle_error
 
 from ._common import IPYTHON_METHODS
 from .bluesky_event_stream import BlueskyEventStreamV2SQL
-from .document import DatumPage, Descriptor, Event, EventPage, Resource, Start, Stop
+from .document import DatumPage, Descriptor, Event, EventPage, Resource, Start, Stop, StreamDatum, StreamResource
 
 _document_types = {
     "start": Start,

--- a/bluesky-tiled-plugins/bluesky_tiled_plugins/catalog_of_bluesky_runs.py
+++ b/bluesky-tiled-plugins/bluesky_tiled_plugins/catalog_of_bluesky_runs.py
@@ -75,6 +75,9 @@ class CatalogOfBlueskyRuns(Container):
 
     @property
     def v3(self):
+        if not self.is_sql:
+            raise NotImplementedError("v3 is only available for SQL-based catalogs.")
+
         structure_clients = copy.copy(self.structure_clients)
         structure_clients.set("BlueskyRun", lambda: BlueskyRunV3)
         return CatalogOfBlueskyRuns(self.context, item=self.item, structure_clients=structure_clients)

--- a/bluesky-tiled-plugins/bluesky_tiled_plugins/document.py
+++ b/bluesky-tiled-plugins/bluesky_tiled_plugins/document.py
@@ -140,6 +140,11 @@ class Resource(Document):
         return ("resource", self["uid"])
 
 
+class StreamResource(Document):
+    def __dask_tokenize__(self):
+        return ("stream_resource", self["uid"])
+
+
 class Descriptor(Document):
     def __dask_tokenize__(self):
         return ("descriptor", self["uid"])
@@ -158,6 +163,11 @@ class EventPage(Document):
 class Datum(Document):
     def __dask_tokenize__(self):
         return ("datum", self["datum_id"])
+
+
+class StreamDatum(Document):
+    def __dask_tokenize__(self):
+        return ("stream_datum", self["uid"])
 
 
 class DatumPage(Document):

--- a/databroker/tests/test_broker.py
+++ b/databroker/tests/test_broker.py
@@ -1209,6 +1209,14 @@ def test_run_read_not_implemented(db, RE, hw):
     with pytest.raises(NotImplementedError):
         h.v2.to_dask()
 
+def test_v3_not_implemented(c, RE, hw):
+    RE.subscribe(c.v1.insert)
+    (uid,) = get_uids(RE(count([hw.det], 5)))
+    with pytest.raises(NotImplementedError):
+        c.v3
+    with pytest.raises(NotImplementedError):
+        c[uid].v3
+
 
 def test_run_metadata(db, RE, hw):
     "Find 'start' and 'stop' in the Entry metadata."


### PR DESCRIPTION
A follow-up PR to #841. Trying to access v3 clients from v2 Mongo-based catalogs raises a `NotImplementedError`.

## How Has This Been Tested?
Added a test in `test_broker.py`