### PR TITLE
add:  root map dict arg to cli tool to extend

### DIFF
--- a/databroker/cli.py
+++ b/databroker/cli.py
@@ -1,4 +1,4 @@
-import ast
+import json
 from typing import List, Optional
 
 import tiled.client
@@ -27,12 +27,14 @@ def parse_dict_arg(arg):
     if arg is None or arg.strip() == '':
         return {}
 
-    result = ast.literal_eval(arg)
-    if isinstance(result, dict):
-        return result
-    else:
-        raise ValueError("Parsed value is not a dictionary.")
-
+    try:
+        result = json.loads(arg)
+        if isinstance(result, dict):
+            return result
+        else:
+            raise ValueError("Parsed value is not a dictionary.")
+    except json.JSONDecodeError as e:
+        raise ValueError(f"Invalid JSON string: {arg}") from e
 
 @admin_app.command("shape-fixer")
 def shape_fix(

--- a/databroker/cli.py
+++ b/databroker/cli.py
@@ -1,12 +1,12 @@
+import ast
 from typing import List, Optional
 
 import tiled.client
 import tiled.server.app
 import typer
-
-from tiled.utils import import_object
 from rich.progress import Progress
-
+from tiled.utils import import_object
+from typing_extensions import Annotated
 
 cli_app = typer.Typer()
 admin_app = typer.Typer()
@@ -15,6 +15,23 @@ cli_app.add_typer(
     name="admin",
     help="Administrative utilities for managing databroker.",
 )
+
+
+def parse_dict_arg(arg):
+    """
+    Parse a string like '{"key1": "value1", "key2": 2}' into a dictionary.
+
+    Returns:
+        dict: The parsed dictionary or an empty dict if arg is None or empty.
+    """
+    if arg is None or arg.strip() == '':
+        return {}
+
+    result = ast.literal_eval(arg)
+    if isinstance(result, dict):
+        return result
+    else:
+        raise ValueError("Parsed value is not a dictionary.")
 
 
 @admin_app.command("shape-fixer")
@@ -29,6 +46,7 @@ def shape_fix(
     handler: Optional[List[str]] = typer.Option(
         None, help="Handler given as 'SPEC = import_path'"
     ),
+    root_map: Annotated[Optional[dict], typer.Option(parser=parse_dict_arg)] = None,
 ):
     """
     Fix shape metadata in Event Descriptors.
@@ -67,6 +85,10 @@ def shape_fix(
         typer.echo(f"Limited to first {limit} BlueskyRuns only")
         items = items[:limit]
 
+    root_map = root_map if root_map is not None else {}
+    root_map = getattr(adapter, "root_map", {}) | root_map
+    typer.echo(f"Using root map: {root_map}")
+
     app = tiled.server.app.build_app(adapter)
     with tiled.client.Context.from_app(app) as context:
         tiled_client = tiled.client.from_context(context)
@@ -81,7 +103,7 @@ def shape_fix(
                             mds_database,
                             asset_database,
                             descriptor,
-                            adapter.root_map,
+                            root_map,
                             handler_registry,
                             patch_resource=patch_resource,
                         )

--- a/databroker/cli.py
+++ b/databroker/cli.py
@@ -36,6 +36,7 @@ def parse_dict_arg(arg):
     except json.JSONDecodeError as e:
         raise ValueError(f"Invalid JSON string: {arg}") from e
 
+
 @admin_app.command("shape-fixer")
 def shape_fix(
     uri: str,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Adds a parser (so that typer can cope with dictionaries) and optional argument to pass a dict as a string to be evaluated.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Root map made this unworkable for rsoxs.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- with correct json dict '{"key": "val"}'
- with incorrect dict
- with not dictionary
- with empty string

<!--
## Screenshots (if appropriate):
-->
