### PR TITLE
add: replace metadata signature for BlueskyEventStream

### DIFF
--- a/databroker/mongo_normalized.py
+++ b/databroker/mongo_normalized.py
@@ -502,7 +502,9 @@ class BlueskyEventStream(MapAdapter):
     def key(self):
         return self._metadata["descriptors"][0]["name"]
 
-    async def replace_metadata(self, metadata=None, specs=None):
+    async def replace_metadata(self, metadata=None, specs=None, drop_revision=False):
+        if drop_revision:
+            raise NotImplementedError("Must use drop_revision=False with databroker.mongo_normalized")
         if "descriptors" not in metadata:
             raise NotImplementedError("Update_metadata method requires descriptors.")
         # Update descriptors

--- a/databroker/tests/test_broker.py
+++ b/databroker/tests/test_broker.py
@@ -1298,6 +1298,16 @@ def test_update(db, RE, hw):
     assert "test_new_start_key" in c[uid].metadata["start"]
     assert c[uid].metadata["start"]["plan_name"] == "test_was_here"
     assert "test_new_stop_key" in c[uid].metadata["stop"]
+
+    # Test stream update
+    md = c[uid]["primary"].get_metadata()[0]
+    md["descriptors"][0]["data_keys"]["det"]["chunks"] = [
+        1 for _ in md["descriptors"][0]["data_keys"]["det"]["shape"]
+    ]
+    c[uid]["primary"].update_metadata(md)
+    assert "chunks" in c[uid]["primary"]["data"]["det"]
+    assert all(x == 1 for x  in c[uid]["primary"]["data"]["det"]["chunks"])
+
     # Note: Vanilla Tiled does not enforce this.
     # Perhaps it could be done at the authorization level.
     # I am not so convinced that this needs to be protected.

--- a/databroker/tests/test_broker.py
+++ b/databroker/tests/test_broker.py
@@ -1300,11 +1300,11 @@ def test_update(db, RE, hw):
     assert "test_new_stop_key" in c[uid].metadata["stop"]
 
     # Test stream update
-    md = c[uid]["primary"].get_metadata()[0]
+    md = c[uid]["primary"].metadata_copy()[0]
     md["descriptors"][0]["data_keys"]["det"]["chunks"] = [
         1 for _ in md["descriptors"][0]["data_keys"]["det"]["shape"]
     ]
-    c[uid]["primary"].update_metadata(md)
+    c[uid]["primary"].update_metadata(metadata=md)
     assert "chunks" in c[uid]["primary"]["data"]["det"]
     assert all(x == 1 for x  in c[uid]["primary"]["data"]["det"]["chunks"])
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
See below. 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
The `replace_metadata` signature was updated for `BlueskyRun`, but not for `BlueskyEventStream`. See [recent release](https://github.com/bluesky/databroker/compare/v2.0.0b60...v2.0.0b61) and 7f4c901.

Was found when trying to update chunking for RSOXS. 
```
  File "/opt/venv/lib/python3.12/site-packages/tiled/server/router.py", line 1480, in patch_metadata
    await entry.replace_metadata(
          ^^^^^^^^^^^^^^^^^^^^^^^
TypeError: BlueskyEventStream.replace_metadata() got an unexpected keyword argument 'drop_revision'
```

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

<!--
## Screenshots (if appropriate):
-->
