### PR TITLE
Add hook to shim in support for new Tiled Authorization

### DIFF
--- a/bluesky-tiled-plugins/bluesky_tiled_plugins/_common.py
+++ b/bluesky-tiled-plugins/bluesky_tiled_plugins/_common.py
@@ -3,4 +3,8 @@
 # resulting in an unnecessary network hit just to raise
 # AttributeError.
 
-IPYTHON_METHODS = {"_ipython_canary_method_should_not_exist_", "_repr_mimebundle_"}
+IPYTHON_METHODS = {
+    "_ipython_canary_method_should_not_exist_",
+    "_repr_mimebundle_"
+    "_ipython_display_"
+}

--- a/bluesky-tiled-plugins/bluesky_tiled_plugins/bluesky_event_stream.py
+++ b/bluesky-tiled-plugins/bluesky_tiled_plugins/bluesky_event_stream.py
@@ -16,6 +16,9 @@ TIMESTAMPS = Sentinel("TIMESTAMPS")
 
 
 class BlueskyEventStream(Container):
+    _ipython_display_ = None
+    _repr_mimebundle__ = None
+
     def __new__(cls, context, *, item, structure_clients, **kwargs):
         # When inheriting from BlueskyEventStream, return the class itself
         if cls is not BlueskyEventStream:

--- a/bluesky-tiled-plugins/bluesky_tiled_plugins/bluesky_run.py
+++ b/bluesky-tiled-plugins/bluesky_tiled_plugins/bluesky_run.py
@@ -29,6 +29,9 @@ RESERVED_V3_KEYS = {"configs", "streams", "views", "aux"}
 
 
 class BlueskyRun(Container):
+    _ipython_display_ = None
+    _repr_mimebundle_ = None
+
     def __new__(cls, context, *, item, structure_clients, **kwargs):
         # When inheriting from BlueskyRun, return the class itself
         if cls is not BlueskyRun:

--- a/databroker/mongo_normalized.py
+++ b/databroker/mongo_normalized.py
@@ -249,7 +249,7 @@ class BlueskyRun(MapAdapter):
 
     @functools.cached_property
     def access_blob(self):
-        return self.authz_shim.access_blob_from_metadata(self.metadata())
+        return self.authz_shim.bluesky_run_access_blob_from_metadata(self.metadata())
 
     def search(self, query):
         if isinstance(query, AccessBlobFilter):
@@ -1363,6 +1363,10 @@ class MongoAdapter(collections.abc.Mapping, IndexersMixin):
         self.query_registry = copy.deepcopy(MongoAdapter.query_registry)
         self.query_registry.register(AccessBlobFilter, self.authz_shim.query_impl)
         super().__init__()
+
+    @property
+    def access_blob(self):
+        return self.authz_shim.catalog_access_blob
 
     @property
     def database(self):

--- a/databroker/mongo_normalized.py
+++ b/databroker/mongo_normalized.py
@@ -247,7 +247,7 @@ class BlueskyRun(MapAdapter):
         self._filler_creation_lock = threading.RLock()
         self.authz_shim = authz_shim
 
-    @property
+    @functools.cached_property
     def access_blob(self):
         return self.authz_shim.access_blob_from_metadata(self.metadata())
 

--- a/databroker/mongo_normalized.py
+++ b/databroker/mongo_normalized.py
@@ -246,7 +246,7 @@ class BlueskyRun(MapAdapter):
         return self.authz_shim.access_blob_from_metadata(self.metadata())
 
     def __repr__(self):
-        metadata = self.metadata
+        metadata = self.metadata()
         datetime_ = datetime.fromtimestamp(metadata["start"]["time"])
         return (
             f"<{type(self).__name__} "

--- a/databroker/mongo_normalized.py
+++ b/databroker/mongo_normalized.py
@@ -199,6 +199,12 @@ class DatasetMapAdapter(MapAdapter):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
 
+    def search(self, query):
+        if isinstance(query, AccessBlobFilter):
+            # No access control is applied below the granularity of a BlueskyRun.
+            return self
+        return super().search(query)
+
     def inlined_contents_enabled(self, depth):
         # Tell the server to in-line the description of each array
         # (i.e. data_vars and coords) to avoid latency of a second
@@ -244,6 +250,12 @@ class BlueskyRun(MapAdapter):
     @property
     def access_blob(self):
         return self.authz_shim.access_blob_from_metadata(self.metadata())
+
+    def search(self, query):
+        if isinstance(query, AccessBlobFilter):
+            # No access control is applied below the granularity of a BlueskyRun.
+            return self
+        return super().search(query)
 
     def __repr__(self):
         metadata = self.metadata()
@@ -479,6 +491,12 @@ class BlueskyEventStream(MapAdapter):
     def __repr__(self):
         return f"<{type(self).__name__} {set(self)!r} stream_name={self.metadata['stream_name']!r}>"
 
+    def search(self, query):
+        if isinstance(query, AccessBlobFilter):
+            # No access control is applied below the granularity of a BlueskyRun.
+            return self
+        return super().search(query)
+
     @property
     def must_revalidate(self):
         # The keys in this node are *always* stable.
@@ -657,6 +675,12 @@ class DatasetFromDocuments:
                 }
             )
         )
+
+    def search(self, query):
+        if isinstance(query, AccessBlobFilter):
+            # No access control is applied below the granularity of a BlueskyRun.
+            return self
+        return super().search(query)
 
     def metadata(self):
         return self._metadata
@@ -1023,7 +1047,12 @@ class Config(MapAdapter):
     MongoAdapter of configuration datasets, keyed on 'object' (e.g. device)
     """
 
-    ...
+    def search(self, query):
+        if isinstance(query, AccessBlobFilter):
+            # No access control is applied below the granularity of a BlueskyRun.
+            return self
+        return super().search(query)
+
 
 
 def build_config_xarray(

--- a/databroker/mongo_normalized.py
+++ b/databroker/mongo_normalized.py
@@ -488,6 +488,10 @@ class BlueskyEventStream(MapAdapter):
         self._cutoff_seq_num = cutoff_seq_num
         self._run = run
 
+    @property
+    def access_blob(self):
+        return self._run.access_blob
+
     def __repr__(self):
         return f"<{type(self).__name__} {set(self)!r} stream_name={self.metadata['stream_name']!r}>"
 
@@ -571,13 +575,14 @@ class ArrayFromDocuments:
 
     structure_family = "array"
 
-    def __init__(self, dataset_adapter, field, specs=None):
+    def __init__(self, dataset_adapter, field, specs=None, access_blob=None):
         self._dataset_adapter = dataset_adapter
         self._field = field
         self._metadata = dataset_adapter.array_metadata[field]
         if specs is None:
             specs = []
         self.specs = specs
+        self.access_blob = access_blob
 
     def metadata(self):
         return self._metadata
@@ -670,11 +675,16 @@ class DatasetFromDocuments:
                         self,
                         field,
                         specs=[Spec("xarray_coord")] if field == "time" else [Spec("xarray_data_var")],
+                        access_blob=self._run.access_blob,
                     )
                     for field in self.array_structures
                 }
             )
         )
+
+    @property
+    def access_blob(self):
+        return self._run.access_blob
 
     def search(self, query):
         if isinstance(query, AccessBlobFilter):


### PR DESCRIPTION
The Tiled Authorization rewrite https://github.com/bluesky/tiled/pull/963 is designed around Tiled's SQL catalog, but to navigate a transition from MongoDB to SQL we need to shim the expected interface here.

This PR includes some unrelated fixes I found along the way.