### PR TITLE
Allow Indexing with Tuples

### DIFF
--- a/bluesky-tiled-plugins/bluesky_tiled_plugins/bluesky_run.py
+++ b/bluesky-tiled-plugins/bluesky_tiled_plugins/bluesky_run.py
@@ -252,6 +252,9 @@ class BlueskyRunV2SQL(BlueskyRunV2, _BlueskyRunSQL):
             stream_container = super().get("streams", {}).get(key)
             return BlueskyEventStreamV2SQL.from_stream_client(stream_container)
 
+        if isinstance(key, tuple):
+            key = "/".join(key)
+
         if "/" in key:
             key, rest = key.split("/", 1)
             return self[key][rest]


### PR DESCRIPTION
Fixes a regression to allow indexing of contents of BlueskyRun v2 with tuples, e.g. `c['run']['primary', 'data']`.


