### PR TITLE
Refactor Handling 'streams' Sub-container

### DIFF
--- a/bluesky-tiled-plugins/bluesky_tiled_plugins/bluesky_run.py
+++ b/bluesky-tiled-plugins/bluesky_tiled_plugins/bluesky_run.py
@@ -321,7 +321,9 @@ class BlueskyRunV2SQL(BlueskyRunV2, _BlueskyRunSQL):
             return (yield from super()._items_slice(start, stop, direction, page_size=page_size, **kwargs))
 
     def __getitem__(self, key):
-        # For v3, we need to handle the streams and configs keys
+        # For v3, we need to handle the streams and configs keys specially
+        if key == "streams":
+            return super().__getitem__("streams")
 
         if isinstance(key, tuple):
             key = "/".join(key)


### PR DESCRIPTION
This refactors handling the back-compatibility of the 'streams' namespace in BlueskyRun containers for both v2 and v3 versions. In v3, if 'streams' is present in the catalog but not supplied by the client, it will be inserted; if 'streams' is NOT present in catalog, but IS supplied by the client, it will be dropped. In both cases, a warning is raised. In v2, using 'streams' will raise a KeyError (this option has never been supported).