### PR TITLE
Fix Recursion Errors in BlueskyRun v2 Client

### DIFF
--- a/bluesky-tiled-plugins/bluesky_tiled_plugins/bluesky_run.py
+++ b/bluesky-tiled-plugins/bluesky_tiled_plugins/bluesky_run.py
@@ -235,7 +235,9 @@ class _BlueskyRunSQL(BlueskyRun):
         2. The specs of the "streams" container do not include "BlueskyEventStream",
            indicating that "streams" is not itself a BlueskyEventStream.
         """
-        return ("streams" in self.base) and ("BlueskyEventStream" not in {s.name for s in self["streams"].specs})
+        return ("streams" in self.base) and (
+            "BlueskyEventStream" not in {s.name for s in self.base["streams"].specs}
+        )
 
     @functools.cached_property
     def _stream_names(self) -> list[str]:
@@ -351,7 +353,7 @@ class BlueskyRunV2SQL(BlueskyRunV2, _BlueskyRunSQL):
         stream_composite_client = super().__getitem__(key)
         stream_container = BlueskyEventStreamV2SQL.from_stream_client(stream_composite_client)
 
-        return stream_container[rest] if rest else stream_container
+        return stream_container[rest[0]] if rest else stream_container
 
 
 class BlueskyRunV3(_BlueskyRunSQL):


### PR DESCRIPTION
This fixes a recursion error in `BlueskyRunSQL` client of bluesky-tiled-adapter after `streams` namespace has been removed in bluesky v1.14.6.
Specifically, a `.base` attributed has been added to the base `BlueskyRun` class, which allows direct access to the underlying `Container` client and simplifies the backcompatibility checks.

Tested with tiled v0.2.0a2 and bluesky v.1.14.5 and 1.14.6:

```python
from bluesky import RunEngine
from bluesky.callbacks.tiled_writer import TiledWriter
import bluesky.plans as bp
from tiled.client import from_uri
from ophyd.sim import det

c = from_uri("http://localhost:8000", api_key="secret")
c.create_container("Y", specs=[Spec("CatalogOfBlueskyRuns")])

RE = RunEngine()
tw = TiledWriter(c['Y'])
RE.subscribe(tw)

uid, = RE(bp.count([det], 10))

print(c['Y'][1])
print(c['Y'][1]['primary'])
print(c['Y'][1]['streams/primary'])
print(c['Y'][1]['streams/primary/det'])
print(c['Y'][1]['primary/det'])
print(c['Y'][1].primary)
print(c['Y'][1].primary['det'])

print(c['Y'][1].v2)
print(c['Y'][1].v2['primary'])
try:
    print(c['Y'][1].v2['streams/primary'])
except KeyError:
    print("KeyError as expected")
try:
    print(c['Y'][1].v2['streams/primary/det'])
except KeyError:
    print("KeyError as expected")
print(c['Y'][1].v2['primary/data/det'])
print(c['Y'][1].v2['primary/config/det'])
print(c['Y'][1].v2.primary)
print(c['Y'][1].v2.primary['data/det'])

print(c['Y'][1].v3)
print(c['Y'][1].v3['primary'])
print(c['Y'][1].v3['streams/primary'])
print(c['Y'][1].v3['streams/primary/det'])
print(c['Y'][1].v3['primary/det'])
print(c['Y'][1].v3.primary)
print(c['Y'][1].v3.primary['det'])
```