### PR TITLE
Avoid sqlalchemy dep

### DIFF
--- a/bluesky-tiled-plugins/bluesky_tiled_plugins/catalog_of_bluesky_runs.py
+++ b/bluesky-tiled-plugins/bluesky_tiled_plugins/catalog_of_bluesky_runs.py
@@ -33,7 +33,7 @@ class CatalogOfBlueskyRuns(Container):
 
     def __repr__(self):
         # This is a copy/paste of the general-purpose implementation
-        # tiled.adapters.utils.tree_repr
+        # tiled.utils.node_repr
         # with some modifications to extract scan_id from the metadata.
         sample = self.items()[:10]
         # Use scan_id (int) if defined; otherwise fall back to uid.

--- a/databroker/mongo_normalized.py
+++ b/databroker/mongo_normalized.py
@@ -37,7 +37,7 @@ from tiled.iterviews import KeysView, ItemsView, ValuesView
 from tiled.query_registration import QueryTranslationRegistry
 from tiled.queries import AccessBlobFilter, Contains, Comparison, Eq, FullText, In, NotEq, NotIn, Regex
 from tiled.structures.core import Spec, StructureFamily
-from tiled.utils import UNCHANGED, IndexersMixin, OneShotCachedMap, import_object, tree_repr
+from tiled.utils import UNCHANGED, IndexersMixin, OneShotCachedMap, import_object, node_repr
 
 from .query_impl import (
     BlueskyMapAdapter,
@@ -1466,7 +1466,7 @@ class MongoAdapter(collections.abc.Mapping, IndexersMixin):
         # Display up to the first N keys to avoid making a giant service
         # request. Use _keys_slicer because it is unauthenticated.
         N = 10
-        return tree_repr(self, self._keys_slice(0, N, direction=1))
+        return node_repr(self, self._keys_slice(0, N, direction=1))
 
     def _get_run(self, run_start_doc):
         "Get a BlueskyRun, either from a cache or by making one if needed."


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

`tiled.adapters.utils` has a sqlalchemy dep now, so the utility `IndexerMixin` was moved to `tiled.utils` in https://github.com/bluesky/tiled/pull/1206.

## Motivation and Context

Import error:

```
File ~/.cache/uv/archive-v0/46g7znwG2xHN6YQAVBduX/lib/python3.9/site-packages/bluesky_tiled_plugins/__init__.py:3
      1 from .bluesky_event_stream import BlueskyEventStream  # noqa: F401
      2 from .bluesky_run import BlueskyRun  # noqa: F401
----> 3 from .catalog_of_bluesky_runs import CatalogOfBlueskyRuns  # noqa: F401
      4 from .tiled_writer import TiledWriter  # noqa: F401
      6 __all__ = [
      7     "BlueskyEventStream",
      8     "BlueskyRun",
      9     "CatalogOfBlueskyRuns",
     10     "TiledWriter",
     11 ]

File ~/.cache/uv/archive-v0/46g7znwG2xHN6YQAVBduX/lib/python3.9/site-packages/bluesky_tiled_plugins/catalog_of_bluesky_runs.py:7
      4 import numbers
      5 import operator
----> 7 from tiled.adapters.utils import IndexCallable
      8 from tiled.client.container import Container
      9 from tiled.client.utils import handle_error

File ~/Repos/bnl/tiled/tiled/adapters/utils.py:4
      1 from collections import defaultdict
      2 from typing import Any, Optional
----> 4 from tiled.adapters.core import A, S
      6 from ..structures.data_source import DataSource
      8 # for back-compat

File ~/Repos/bnl/tiled/tiled/adapters/core.py:5
      2 from collections.abc import Set
      3 from typing import Any, Generic, List, Optional, TypeVar
----> 5 from tiled.storage import Storage
      6 from tiled.structures.core import Spec, StructureFamily
      7 from tiled.structures.root import Structure

File ~/Repos/bnl/tiled/tiled/storage.py:9
      6 from typing import TYPE_CHECKING, Dict, Literal, Optional, Union
      7 from urllib.parse import urlparse, urlunparse
----> 9 import sqlalchemy.pool
     11 from .utils import ensure_uri, path_from_uri, sanitize_uri
     13 if TYPE_CHECKING:

ModuleNotFoundError: No module named 'sqlalchemy'
```

## How Has This Been Tested?

We don't have the harness set up to test a client-only install on CI, but this resolves the issue in a local test.

<!--
## Screenshots (if appropriate):
-->
