### PR TITLE
Internal Arrays as zarr

### DIFF
--- a/bluesky-tiled-plugins/bluesky_tiled_plugins/consolidators.py
+++ b/bluesky-tiled-plugins/bluesky_tiled_plugins/consolidators.py
@@ -18,6 +18,37 @@ class Patch:
     shape: tuple[int, ...]
     offset: tuple[int, ...]
 
+    @classmethod
+    def combine_patches(cls, patches: list["Patch"]) -> "Patch":
+        """Combine multiple patches into a single patch
+
+        The combined patch covers the union (smallest bounding box) of all provided patches.
+
+        Parameters
+        ----------
+        patches : list[Patch]
+            A list of Patch objects to combine.
+
+        Returns
+        -------
+        Patch
+            A new Patch object that covers the union of all input patches.
+        """
+
+        # Determine the overall shape and offset
+        min_offset = list(patches[0].offset)
+        max_extent = [offset + size for offset, size in zip(patches[0].offset, patches[0].shape)]
+
+        for patch in patches[1:]:
+            for i in range(len(min_offset)):
+                min_offset[i] = min(min_offset[i], patch.offset[i])
+                max_extent[i] = max(max_extent[i], patch.offset[i] + patch.shape[i])
+
+        combined_shape = tuple(max_e - min_o for min_o, max_e in zip(min_offset, max_extent))
+        combined_offset = tuple(min_offset)
+
+        return cls(shape=combined_shape, offset=combined_offset)
+
 
 class ConsolidatorBase:
     """Consolidator of StreamDatums

--- a/bluesky-tiled-plugins/tests/examples/internal_events.json
+++ b/bluesky-tiled-plugins/tests/examples/internal_events.json
@@ -85,13 +85,20 @@
                     "dtype": "array",
                     "shape": [],
                     "object_name": "det"
+                },
+                "long": {
+                    "source": "SIM:det",
+                    "dtype": "array",
+                    "shape": [8],
+                    "object_name": "det"
                 }
             },
             "name": "primary",
             "object_keys": {
                 "det": [
                     "det",
-                    "empty"
+                    "empty",
+                    "long"
                 ]
             },
             "run_start": "{{ uuid }}-dc0518f354ee",
@@ -101,7 +108,8 @@
                 "det": {
                     "fields": [
                         "det",
-                        "empty"
+                        "empty",
+                        "long"
                     ]
                 }
             }
@@ -114,11 +122,13 @@
             "time": 1745338531.215753,
             "data": {
                 "det": 1.0,
-                "empty": []
+                "empty": [],
+                "long": [0, 1, 2, 3, 4, 5, 6, 7]
             },
             "timestamps": {
                 "det": 1745338531.001646,
-                "empty": 1745338531.001647
+                "empty": 1745338531.001647,
+                "long": 1745338531.001648
             },
             "seq_num": 1,
             "filled": {},
@@ -132,11 +142,13 @@
             "time": 1745338531.218661,
             "data": {
                 "det": 1.0,
-                "empty": []
+                "empty": [],
+                "long": [10, 11, 12, 13, 14, 15, 16, 17]
             },
             "timestamps": {
                 "det": 1745338531.217144,
-                "empty": 1745338531.217145
+                "empty": 1745338531.217145,
+                "long": 1745338531.217146
             },
             "seq_num": 2,
             "filled": {},
@@ -214,13 +226,20 @@
                     "dtype": "array",
                     "shape": [],
                     "object_name": "det"
+                },
+                "long": {
+                    "source": "SIM:det",
+                    "dtype": "array",
+                    "shape": [8],
+                    "object_name": "det"
                 }
             },
             "name": "primary",
             "object_keys": {
                 "det": [
                     "det",
-                    "empty"
+                    "empty",
+                    "long"
                 ]
             },
             "run_start": "{{ uuid }}-dc0518f354ee",
@@ -230,7 +249,8 @@
                 "det": {
                     "fields": [
                         "det",
-                        "empty"
+                        "empty",
+                        "long"
                     ]
                 }
             }
@@ -243,11 +263,13 @@
             "time": 1745338533.2213702,
             "data": {
                 "det": 1.0,
-                "empty": []
+                "empty": [],
+                "long": [20, 21, 22, 23, 24, 25, 26, 27]
             },
             "timestamps": {
                 "det": 1745338533.219767,
-                "empty": 1745338533.219768
+                "empty": 1745338533.219768,
+                "long": 1745338533.219769
             },
             "seq_num": 3,
             "filled": {},


### PR DESCRIPTION
1. This allows one to write long arrays encountered in Event documents into zarr storage (instead of into the tabular storage).

2. Moreover, the code for emptying the cache of external data has been refactored to avoid repeating `PUT` requests to `data_source` endpoint if multiple `StreamDatums` in the cache update the same `data_source`.
