### PR TITLE
Use read_block when reading slices of the entire arrays

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ghcr.io/bluesky/tiled:0.1.0-b36 as base
+FROM ghcr.io/bluesky/tiled:0.2.11 as base
 
 USER root
 COPY . /databroker-src/

--- a/databroker/mongo_normalized.py
+++ b/databroker/mongo_normalized.py
@@ -38,6 +38,7 @@ from tiled.query_registration import QueryTranslationRegistry
 from tiled.queries import AccessBlobFilter, Contains, Comparison, Eq, FullText, In, NotEq, NotIn, Regex
 from tiled.structures.core import Spec, StructureFamily
 from tiled.utils import UNCHANGED, IndexersMixin, OneShotCachedMap, import_object, node_repr
+from tiled.ndslice import block_for_slice, build_nested_grid
 
 from .query_impl import (
     BlueskyMapAdapter,
@@ -584,8 +585,17 @@ class ArrayFromDocuments:
         return self._dataset_adapter.read_block(self._field, block, slice=slice)
 
     def read(self, slice=None):
-        array_adapter = self._dataset_adapter.read(fields=[self._field])[self._field]
-        return array_adapter.read(slice)
+        structure = self._dataset_adapter.array_structures[self._field]
+        block, slice_in_block = block_for_slice(structure.chunks, slice)
+        chunk_indices = block.chunk_indices(structure.chunks)
+
+        array = numpy.block(
+            build_nested_grid(
+                chunk_indices, lambda idx: self.read_block(block=idx, slice=None)
+            )
+        )
+
+        return array[slice_in_block]
 
     def structure(self):
         return self._dataset_adapter.array_structures[self._field]

--- a/requirements-client.txt
+++ b/requirements-client.txt
@@ -1,4 +1,4 @@
 bluesky-tiled-plugins
 msgpack >=1.0.0
 orjson
-tiled[client] >=0.1.0b30
+tiled[client] >=0.2.11

--- a/requirements-server.txt
+++ b/requirements-server.txt
@@ -17,7 +17,7 @@ pytz
 rich
 starlette
 suitcase-mongo >=0.5.0
-tiled[server] >=0.1.0b30
+tiled[server] >=0.2.11
 toolz
 typer
 tzlocal

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -17,6 +17,6 @@ sphinx
 suitcase-jsonl >=0.1.0b2
 suitcase-mongo >=0.5.0
 suitcase-msgpack >=0.2.2
-tiled[all] >=0.1.0b30
+tiled[all] >=0.2.11
 ujson
 vcrpy


### PR DESCRIPTION
Use `read_block` methods for reading slices of array data.

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
When reading slices of big arrays, Tiled by default calls the `.read(slice=...)` method, which causes databroker to fetch data for the entire array, event hough most of it may be discarded during slicing. These changes allow the server to only fetch necessary chunks.

## How Has This Been Tested?
Utility functions are tested in Tiled. Full workflow is tested in a dev set-up with mounted MongoDB.
